### PR TITLE
Parse the the cmdline arguments more perfectly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,11 @@ $(OUT)/bzImage:
 $(OUT)/rootfs.cpio:
 	$(Q)scripts/build-rootfs.sh
 
+rootfs: $(OUT)/rootfs.cpio
+
 check: $(BIN) $(OUT)/bzImage $(OUT)/rootfs.cpio
 	$(VECHO) "\nOnce the message 'Kernel panic' appears, press ctrl-c to exit\n"
-	$(Q)sudo ./$^
+	$(Q)sudo $(BIN) -k $(OUT)/bzImage -i $(OUT)/rootfs.cpio
 
 clean:
 	$(VECHO) "Cleaning...\n"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Download and build Linux kernel from scratch:
 make build/bzImage
 ```
 
+Download and build Busybox for root file system from scratch:
+```shell
+make rootfs
+```
+
 Run Linux guest with `kvm-host`:
 ```shell
 make check
@@ -23,10 +28,12 @@ make check
 ## Usage
 
 ```
-kvm-host [bzImage]
+build/kvm-host -k bzImage [-i initrd]
 ```
 
-`bzImage` is the Path to linux kernel bzImage. The bzImage file is in a specific format, containing concatenated `bootsect.o + setup.o + misc.o + piggy.o`.
+`bzImage` is the path to linux kernel bzImage. The bzImage file is in a specific format,
+containing concatenated `bootsect.o + setup.o + misc.o + piggy.o`. `initrd` is the path to
+initial RAM disk image, which is an optional argument.
 
 ## License
 

--- a/src/kvm-host.c
+++ b/src/kvm-host.c
@@ -1,21 +1,59 @@
+#include <getopt.h>
+#include <stdlib.h>
+
 #include "err.h"
 #include "vm.h"
 
+static char *kernel_file = NULL;
+static char *initrd_file = NULL;
+
+#define print_option(args, help_msg) printf("  %-30s%s", args, help_msg)
+
+static void usage(const char *execpath)
+{
+    printf("\n usage: %s -k bzImage [options]\n\n", execpath);
+    printf("options:\n");
+
+    print_option("-h, --help", "Print help of CLI and exit.\n");
+    print_option("-i, --initrd initrd", "Initial RAM disk image\n");
+}
+
 int main(int argc, char *argv[])
 {
-    if (argc != 3)
-        return fprintf(stderr, "Usage: %s [filename] [initrd filename]\n",
-                       argv[0]);
+    int option_index = 0;
+    struct option opts[] = {{"kernel", 1, NULL, 'k'},
+                            {"initrd", 1, NULL, 'i'},
+                            {"help", 0, NULL, 'h'}};
+
+    int c;
+    while ((c = getopt_long(argc, argv, "k:i:h", opts, &option_index)) != -1) {
+        switch (c) {
+        case 'i':
+            initrd_file = optarg;
+            break;
+        case 'k':
+            kernel_file = optarg;
+            break;
+        case 'h':
+            usage(argv[0]);
+            exit(123);
+        default:
+            break;
+        }
+    }
 
     vm_t vm;
     if (vm_init(&vm) < 0)
         return throw_err("Failed to initialize guest vm");
 
-    if (vm_load_image(&vm, argv[1]) < 0)
-        return throw_err("Failed to load guest image");
+    if (!kernel_file)
+        return throw_err(
+            "The kernel image must be used as the input of kvm-host!");
 
-    if (vm_load_initrd(&vm, argv[2]) < 0)
+    if (vm_load_image(&vm, kernel_file) < 0)
         return throw_err("Failed to load guest image");
+    if (initrd_file && vm_load_initrd(&vm, initrd_file) < 0)
+        return throw_err("Failed to load initrd");
 
     vm_run(&vm);
     vm_exit(&vm);


### PR DESCRIPTION
I try to use `getopt` to build a standard mechanism to parse command-line options, so it would be more easily to add new option in the future. This patch also makes the `initrd` input to be optional, since it is not indispensable for `kvm-host`. `README.md` is also changed accordingly for the new command-line interface.

The design of the command-line interface is just my favorite style, but I'm not sure if there's any insufficient. Please tell me if there's any bad implementation that should be revised.