### PR TITLE
Emulate the basic requiremnt of UART to boot Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CC ?= gcc
 CFLAGS = -O2
 CFLAGS += -Wall -std=gnu99
 CFLAGS += -g
+LDFLAGS = -lpthread
 
 OUT ?= build
 BIN = $(OUT)/kvm-host
@@ -17,13 +18,13 @@ else
     VECHO = @printf
 endif
 
-OBJS := vm.o kvm-host.o
+OBJS := vm.o serial.o kvm-host.o
 OBJS := $(addprefix $(OUT)/,$(OBJS))
 deps := $(OBJS:%.o=%.o.d)
 
 $(BIN): $(OBJS)
 	$(VECHO) "  LD\t$@\n"
-	$(Q)$(CC) $(LDFLAGS) -o $@ $^
+	$(Q)$(CC) $(LDFLAGS) -o $@ $^ $(LDFLAGS)
 
 $(OUT)/%.o: src/%.c
 	$(Q)mkdir -p $(OUT)

--- a/src/serial.c
+++ b/src/serial.c
@@ -1,0 +1,223 @@
+#include <linux/serial_reg.h>
+#include <poll.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "serial.h"
+#include "utils.h"
+#include "vm.h"
+
+#define SERIAL_IRQ 4
+#define IO_READ8(data) *((uint8_t *) data)
+#define IO_WRITE8(data, value) ((uint8_t *) data)[0] = value
+
+/* global state to stop the loop of thread */
+static volatile bool thread_stop = false;
+
+struct serial_dev_priv {
+    uint8_t dll;
+    uint8_t dlm;
+    uint8_t iir;
+    uint8_t ier;
+    uint8_t fcr;
+    uint8_t lcr;
+    uint8_t mcr;
+    uint8_t lsr;
+    uint8_t msr;
+    uint8_t scr;
+
+    struct fifo rx_buf;
+};
+
+static struct serial_dev_priv serial_dev_priv = {
+    .iir = UART_IIR_NO_INT,
+    .mcr = UART_MCR_OUT2,
+    .lsr = UART_LSR_TEMT | UART_LSR_THRE,
+    .msr = UART_MSR_DCD | UART_MSR_DSR | UART_MSR_CTS,
+};
+
+/* FIXME: This implementation is incomplete */
+static void serial_update_irq(serial_dev_t *s)
+{
+    struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
+    uint8_t iir = UART_IIR_NO_INT;
+
+    /* If enable receiver data interrupt and receiver data ready */
+    if ((priv->ier & UART_IER_RDI) && (priv->lsr & UART_LSR_DR))
+        iir = UART_IIR_RDI;
+    /* If enable transmiter data interrupt and transmiter empty */
+    else if ((priv->ier & UART_IER_THRI) && (priv->lsr & UART_LSR_TEMT))
+        iir = UART_IIR_THRI;
+
+    priv->iir = iir | 0xc0;
+
+    /* FIXME: the return error of vm_irq_line should be handled */
+    vm_irq_line(container_of(s, vm_t, serial), SERIAL_IRQ,
+                iir == UART_IIR_NO_INT ? 0 /* inactive */ : 1 /* active */);
+}
+
+static int serial_readable(serial_dev_t *s)
+{
+    struct pollfd pollfd = (struct pollfd){
+        .fd = s->infd,
+        .events = POLLIN,
+    };
+    return (poll(&pollfd, 1, 0) > 0) && (pollfd.revents & POLLIN);
+}
+
+static void serial_console(serial_dev_t *s)
+{
+    struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
+
+    while (!__atomic_load_n(&thread_stop, __ATOMIC_RELAXED)) {
+        pthread_mutex_lock(&s->lock);
+
+        if (priv->lsr & UART_LSR_DR || !fifo_is_empty(&priv->rx_buf))
+            goto unlock;
+
+        while (!fifo_is_full(&priv->rx_buf) && serial_readable(s)) {
+            char c;
+            if (read(s->infd, &c, 1) == -1)
+                break;
+            if (!fifo_put(&priv->rx_buf, c))
+                break;
+            priv->lsr |= UART_LSR_DR;
+        }
+        serial_update_irq(s);
+    unlock:
+        pthread_mutex_unlock(&s->lock);
+    }
+}
+
+static void serial_in(serial_dev_t *s, uint16_t offset, void *data)
+{
+    struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
+
+    pthread_mutex_lock(&s->lock);
+
+    switch (offset) {
+    case UART_RX:
+        if (priv->lcr & UART_LCR_DLAB) {
+            IO_WRITE8(data, priv->dll);
+        } else {
+            if (fifo_is_empty(&priv->rx_buf))
+                break;
+
+            uint8_t value;
+            if (fifo_get(&priv->rx_buf, value))
+                IO_WRITE8(data, value);
+
+            if (fifo_is_empty(&priv->rx_buf)) {
+                priv->lsr &= ~UART_LSR_DR;
+                serial_update_irq(s);
+            }
+        }
+        break;
+    case UART_IER:
+        if (priv->lcr & UART_LCR_DLAB)
+            IO_WRITE8(data, priv->dlm);
+        else
+            IO_WRITE8(data, priv->ier);
+        break;
+    case UART_IIR:
+        IO_WRITE8(data, priv->iir | 0xc0);  // 0xc0 stands for FIFO enabled
+        break;
+    case UART_LCR:
+        IO_WRITE8(data, priv->lcr);
+        break;
+    case UART_MCR:
+        IO_WRITE8(data, priv->mcr);
+        break;
+    case UART_LSR:
+        IO_WRITE8(data, priv->lsr);
+        break;
+    case UART_MSR:
+        IO_WRITE8(data, priv->msr);
+        break;
+    case UART_SCR:
+        IO_WRITE8(data, priv->scr);
+        break;
+    default:
+        break;
+    }
+    pthread_mutex_unlock(&s->lock);
+}
+
+static void serial_out(serial_dev_t *s, uint16_t offset, void *data)
+{
+    struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
+
+    pthread_mutex_lock(&s->lock);
+
+    switch (offset) {
+    case UART_TX:
+        if (priv->lcr & UART_LCR_DLAB) {
+            priv->dll = IO_READ8(data);
+        } else {
+            priv->lsr |= (UART_LSR_TEMT | UART_LSR_THRE);  // flush TX
+            putchar(((char *) data)[0]);
+            fflush(stdout);
+            serial_update_irq(s);
+        }
+        break;
+    case UART_IER:
+        if (!(priv->lcr & UART_LCR_DLAB)) {
+            priv->ier = IO_READ8(data);
+            serial_update_irq(s);
+        } else {
+            priv->dlm = IO_READ8(data);
+        }
+        break;
+    case UART_FCR:
+        priv->fcr = IO_READ8(data);
+        break;
+    case UART_LCR:
+        priv->lcr = IO_READ8(data);
+        break;
+    case UART_MCR:
+        priv->mcr = IO_READ8(data);
+        break;
+    case UART_LSR:  // factory test
+    case UART_MSR:  // not used
+        break;
+    case UART_SCR:
+        priv->scr = IO_READ8(data);
+        break;
+    default:
+        break;
+    }
+    pthread_mutex_unlock(&s->lock);
+}
+
+void serial_init(serial_dev_t *s)
+{
+    *s = (serial_dev_t){
+        .priv = (void *) &serial_dev_priv,
+    };
+
+    pthread_mutex_init(&s->lock, NULL);
+    s->infd = STDIN_FILENO;
+    // create a thread which accepts serial input
+    pthread_create(&s->worker_tid, NULL, (void *) serial_console, (void *) s);
+}
+
+void serial_handle(serial_dev_t *s, struct kvm_run *r)
+{
+    uint32_t count = r->io.count;
+    void *data = (uint8_t *) r + r->io.data_offset;
+    void (*serial_op)(serial_dev_t *, uint16_t, void *) =
+        (r->io.direction == KVM_EXIT_IO_OUT) ? serial_out : serial_in;
+    for (uint16_t offset = r->io.port - COM1_PORT_BASE; count--;
+         data += r->io.size)
+        serial_op(s, offset, data);
+}
+
+void serial_exit(serial_dev_t *s)
+{
+    __atomic_store_n(&thread_stop, true, __ATOMIC_RELAXED);
+    pthread_join(s->worker_tid, NULL);
+    pthread_mutex_destroy(&s->lock);
+}

--- a/src/serial.h
+++ b/src/serial.h
@@ -1,0 +1,25 @@
+#ifndef SERIAL_H
+#define SERIAL_H
+
+#include <linux/kvm.h>
+#include <pthread.h>
+#include <stdint.h>
+
+#define COM1_PORT_BASE 0x03f8
+#define COM1_PORT_SIZE 8
+#define COM1_PORT_END (COM1_PORT_BASE + COM1_PORT_SIZE)
+
+typedef struct serial_dev serial_dev_t;
+
+struct serial_dev {
+    void *priv;
+    pthread_mutex_t lock;
+    pthread_t worker_tid;
+    int infd;  // file descriptor for serial input
+};
+
+void serial_init(serial_dev_t *s);
+void serial_handle(serial_dev_t *s, struct kvm_run *r);
+void serial_exit(serial_dev_t *s);
+
+#endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,43 @@
+#ifndef UTILS_H
+#define UTILS_H
+
+#define container_of(ptr, type, member)               \
+    ({                                                \
+        void *__mptr = (void *) (ptr);                \
+        ((type *) (__mptr - offsetof(type, member))); \
+    })
+
+#define FIFO_LEN 64
+#define FIFO_MASK (FIFO_LEN - 1)
+
+struct fifo {
+    uint8_t data[FIFO_LEN];
+    unsigned int head;
+    unsigned int tail;
+};
+
+#define fifo_is_empty(fifo) ((fifo)->head == (fifo)->tail)
+
+#define fifo_is_full(fifo) ((fifo)->tail - (fifo)->head > FIFO_MASK)
+
+#define fifo_put(fifo, value)                               \
+    ({                                                      \
+        unsigned int __ret = !fifo_is_full(fifo);           \
+        if (__ret) {                                        \
+            (fifo)->data[(fifo)->tail & FIFO_MASK] = value; \
+            (fifo)->tail++;                                 \
+        }                                                   \
+        __ret;                                              \
+    })
+
+#define fifo_get(fifo, value)                               \
+    ({                                                      \
+        unsigned int __ret = !fifo_is_empty(fifo);          \
+        if (__ret) {                                        \
+            value = (fifo)->data[(fifo)->head & FIFO_MASK]; \
+            (fifo)->head++;                                 \
+        }                                                   \
+        __ret;                                              \
+    })
+
+#endif

--- a/src/vm.h
+++ b/src/vm.h
@@ -4,15 +4,19 @@
 #define RAM_SIZE (1 << 30)
 #define KERNEL_OPTS "console=ttyS0"
 
+#include "serial.h"
+
 typedef struct {
     int kvm_fd, vm_fd, vcpu_fd;
     void *mem;
+    serial_dev_t serial;
 } vm_t;
 
 int vm_init(vm_t *v);
 int vm_load_image(vm_t *v, const char *image_path);
 int vm_load_initrd(vm_t *v, const char *initrd_path);
 int vm_run(vm_t *v);
+int vm_irq_line(vm_t *v, int irq, int level);
 void vm_exit(vm_t *v);
 
 #endif


### PR DESCRIPTION
This patch implements more emulation of the serial UART. Therefore, we can perform serial communications more completely, including receive information and interact with the command line for some BusyBox Unix utilities.

There are some options for implementation which could be discussed according to your decision of the development of this project:
* The implementation of UART now could be more complete or simpler. It depends on what we are going to do with the loading kernel image.
*  You mentioned the possibility to use coroutine instead of thread to implement UART. However, I'm not sure if it is worth for our current requirements:
    * If no condition (e.g. interrupted by I/O) which should be handled by our program happens, VM will always run inside the loop of `KVM_RUN` ioctl. If we want to yield the control back from `KVM_RUN` ioctl for the coroutine, we may need more mechanisms (e.g. timer?) to achieve this. So things would become harder.
    * The task of the created thread is very simple now. If there are no other tasks (e.g. other hardware emulation), I'm not sure of the necessity of the coroutine. Coupling with there are many ways to design for coroutine mechanism, I can't decide for the best implementation for this project.