### PR TITLE
Handle serial input using timerfd mechanism 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC ?= gcc
 CFLAGS = -O2
 CFLAGS += -Wall -std=gnu99
 CFLAGS += -g
-LDFLAGS = -lpthread
+LDFLAGS = -lpthread -lrt
 
 OUT ?= build
 BIN = $(OUT)/kvm-host

--- a/src/serial.h
+++ b/src/serial.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <linux/kvm.h>
-#include <pthread.h>
 
 #define COM1_PORT_BASE 0x03f8
 #define COM1_PORT_SIZE 8
@@ -11,11 +10,9 @@ typedef struct serial_dev serial_dev_t;
 
 struct serial_dev {
     void *priv;
-    pthread_mutex_t lock;
-    pthread_t worker_tid;
     int infd; /* file descriptor for serial input */
 };
 
+void serial_console(serial_dev_t *s);
 void serial_init(serial_dev_t *s);
 void serial_handle(serial_dev_t *s, struct kvm_run *r);
-void serial_exit(serial_dev_t *s);

--- a/src/vm.h
+++ b/src/vm.h
@@ -4,8 +4,10 @@
 #define KERNEL_OPTS "console=ttyS0"
 
 #include "serial.h"
+#include <pthread.h>
 
 typedef struct {
+    pthread_t timer_tid;
     int kvm_fd, vm_fd, vcpu_fd;
     void *mem;
     serial_dev_t serial;


### PR DESCRIPTION
This PR is related to #4.

The problem of serial implementation is: If no condition which should be handled happens, VM will always run inside the loop of KVM_RUN ioctl. To solve the issue, the previous solution of kvm-host is using another thread to handle serial input. On the other hand, another solution is using a timer to periodically return from KVM_RUN ioctl. The latter solution may not certainly be more efficient. For example, although no POSIX thread is needed for the latter solution, the timer interrupt may cause extra cost if we return from KVM_RUN ioctl without anything that needs to be handled.

But if we only consider the simplicity, the latter solution seems to be indeed better. So we change the implementation for such reason now.