### PR TITLE
Handle serial input without lock

### DIFF
--- a/src/serial.c
+++ b/src/serial.c
@@ -1,5 +1,6 @@
 #include <linux/serial_reg.h>
 #include <poll.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -7,6 +8,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#include "err.h"
 #include "serial.h"
 #include "utils.h"
 #include "vm.h"
@@ -14,9 +16,6 @@
 #define SERIAL_IRQ 4
 #define IO_READ8(data) *((uint8_t *) data)
 #define IO_WRITE8(data, value) ((uint8_t *) data)[0] = value
-
-/* global state to stop the loop of thread */
-static volatile bool thread_stop = false;
 
 struct serial_dev_priv {
     uint8_t dll;
@@ -60,44 +59,52 @@ static void serial_update_irq(serial_dev_t *s)
                 iir == UART_IIR_NO_INT ? 0 /* inactive */ : 1 /* active */);
 }
 
-static int serial_readable(serial_dev_t *s)
+static int serial_readable(serial_dev_t *s, int timeout)
 {
     struct pollfd pollfd = (struct pollfd){
         .fd = s->infd,
         .events = POLLIN,
     };
-    return (poll(&pollfd, 1, 0) > 0) && (pollfd.revents & POLLIN);
+    return (poll(&pollfd, 1, timeout) > 0) && (pollfd.revents & POLLIN);
 }
 
-static void serial_console(serial_dev_t *s)
+#define FREQ_NS ((int) (1.0e6))
+#define NS_PER_SEC ((int) (1.0e9))
+
+/* global state to stop the loop of thread */
+static volatile bool thread_stop = false;
+
+static void *serial_thread(serial_dev_t *s)
+{
+    while (!__atomic_load_n(&thread_stop, __ATOMIC_RELAXED)) {
+        if (serial_readable(s, -1))
+            pthread_kill((pthread_t) s->main_tid, SIGUSR1);
+    }
+
+    return NULL;
+}
+
+void serial_console(serial_dev_t *s)
 {
     struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
 
-    while (!__atomic_load_n(&thread_stop, __ATOMIC_RELAXED)) {
-        pthread_mutex_lock(&s->lock);
+    if (priv->lsr & UART_LSR_DR || !fifo_is_empty(&priv->rx_buf))
+        return;
 
-        if (priv->lsr & UART_LSR_DR || !fifo_is_empty(&priv->rx_buf))
-            goto unlock;
-
-        while (!fifo_is_full(&priv->rx_buf) && serial_readable(s)) {
-            char c;
-            if (read(s->infd, &c, 1) == -1)
-                break;
-            if (!fifo_put(&priv->rx_buf, c))
-                break;
-            priv->lsr |= UART_LSR_DR;
-        }
-        serial_update_irq(s);
-    unlock:
-        pthread_mutex_unlock(&s->lock);
+    while (!fifo_is_full(&priv->rx_buf) && serial_readable(s, 0)) {
+        char c;
+        if (read(s->infd, &c, 1) == -1)
+            break;
+        if (!fifo_put(&priv->rx_buf, c))
+            break;
+        priv->lsr |= UART_LSR_DR;
     }
+    serial_update_irq(s);
 }
 
 static void serial_in(serial_dev_t *s, uint16_t offset, void *data)
 {
     struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
-
-    pthread_mutex_lock(&s->lock);
 
     switch (offset) {
     case UART_RX:
@@ -144,14 +151,11 @@ static void serial_in(serial_dev_t *s, uint16_t offset, void *data)
     default:
         break;
     }
-    pthread_mutex_unlock(&s->lock);
 }
 
 static void serial_out(serial_dev_t *s, uint16_t offset, void *data)
 {
     struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
-
-    pthread_mutex_lock(&s->lock);
 
     switch (offset) {
     case UART_TX:
@@ -190,19 +194,40 @@ static void serial_out(serial_dev_t *s, uint16_t offset, void *data)
     default:
         break;
     }
-    pthread_mutex_unlock(&s->lock);
 }
 
-void serial_init(serial_dev_t *s)
+static void handler(int sig, siginfo_t *si, void *uc) {}
+
+int serial_init(serial_dev_t *s)
 {
+    struct sigaction sa;
+    sigset_t mask;
+
+    sa.sa_flags = SA_SIGINFO;
+    sa.sa_sigaction = handler;
+    sigemptyset(&sa.sa_mask);
+    if (sigaction(SIGUSR1, &sa, NULL) == -1)
+        return throw_err("Failed to create signal handler");
+
+    /* Block timer signal temporarily. */
+    sigemptyset(&mask);
+    sigaddset(&mask, SIGUSR1);
+    if (sigprocmask(SIG_SETMASK, &mask, NULL) == -1)
+        return throw_err("Failed to block timer signal");
+
     *s = (serial_dev_t){
         .priv = (void *) &serial_dev_priv,
+        .main_tid = pthread_self(),
+        .infd = STDIN_FILENO,
     };
+    pthread_create(&s->worker_tid, NULL, (void *) serial_thread, (void *) s);
 
-    pthread_mutex_init(&s->lock, NULL);
-    s->infd = STDIN_FILENO;
-    /* create a thread which accepts serial input */
-    pthread_create(&s->worker_tid, NULL, (void *) serial_console, (void *) s);
+    /* Unlock the timer signal, so that timer notification
+     * can be delivered. */
+    if (sigprocmask(SIG_UNBLOCK, &mask, NULL) == -1)
+        return throw_err("Failed to unblock timer signal");
+
+    return 0;
 }
 
 void serial_handle(serial_dev_t *s, struct kvm_run *r)
@@ -220,5 +245,4 @@ void serial_exit(serial_dev_t *s)
 {
     __atomic_store_n(&thread_stop, true, __ATOMIC_RELAXED);
     pthread_join(s->worker_tid, NULL);
-    pthread_mutex_destroy(&s->lock);
 }

--- a/src/serial.h
+++ b/src/serial.h
@@ -11,11 +11,11 @@ typedef struct serial_dev serial_dev_t;
 
 struct serial_dev {
     void *priv;
-    pthread_mutex_t lock;
-    pthread_t worker_tid;
+    pthread_t main_tid, worker_tid;
     int infd; /* file descriptor for serial input */
 };
 
-void serial_init(serial_dev_t *s);
+void serial_console(serial_dev_t *s);
+int serial_init(serial_dev_t *s);
 void serial_handle(serial_dev_t *s, struct kvm_run *r);
 void serial_exit(serial_dev_t *s);


### PR DESCRIPTION
This PR is going to solved #4, and some of the discussion and where this comes from can be found in #5.

The problem of serial implementation is: If no specific condition which should be handled in userspace happens, VM will always run inside the loop of `KVM_RUN` ioctl in kernel. The user's keyboard inputs can't make it return from kernel directly.

To solve the issue, the previous solution of `kvm-host` uses another worker thread to handle serial input itself, which will need an extra mutex because it will access the VM-related data. However, under the implementation, we can't manage the code
flow of main thread and worker thread narrowly, since they'll schedule by our operating system. And we also need to carefully define the critical section for both the performance and correctness.

Because of those reasons, this patch makes a reimplementation. Now, although we still need a thread
for `kvm-host`, the worker thread doesn't access the VM-related data. Instead, it just "tells" the main thread that it needs to spend some time for the serial inputs first by signal. So we don't need to worry about data race under this design, which makes everything simple. And we can also improve the cooperative because now we can decide the code flow between serial input and KVM instead of partially depending on the operating system.