### PR TITLE
Handle multi-threaded FIFO operations in serial device

### DIFF
--- a/src/serial.c
+++ b/src/serial.c
@@ -1,11 +1,17 @@
+#include <fcntl.h>
 #include <linux/serial_reg.h>
-#include <poll.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/uio.h>
 #include <unistd.h>
 
 #include "err.h"
@@ -17,7 +23,22 @@
 #define IO_READ8(data) *((uint8_t *) data)
 #define IO_WRITE8(data, value) ((uint8_t *) data)[0] = value
 
+#define IER_MASK 0x0f
+#define MCR_MASK 0x1f
+#define FCR_MASK 0xc9
+#define DEFAULT_MSR UART_MSR_DCD | UART_MSR_DSR | UART_MSR_CTS
+
+#define SERIAL_EPOLL_EVENT 1
+#define SERIAL_EPOLL_OUT 2
+#define SERIAL_EPOLL_IN 3
+
+#define SERIAL_TRIG_LEVELS \
+    {                      \
+        1, 16, 32, 56      \
+    }
+
 struct serial_dev_priv {
+    /* Device registers */
     uint8_t dll;
     uint8_t dlm;
     uint8_t iir;
@@ -28,8 +49,27 @@ struct serial_dev_priv {
     uint8_t lsr;
     uint8_t msr;
     uint8_t scr;
+    bool thr_ipending;
 
+    /* Buffers */
+    struct fifo tx_buf;
     struct fifo rx_buf;
+    uint8_t rxtrig;
+
+    /* File descriptors */
+    int infd;
+    int outfd;
+    int evfd;
+    int epollfd;
+
+    /* Worker */
+    pthread_t worker;
+    pthread_mutex_t lock;
+    pthread_mutex_t loopback_lock;
+    bool stopped;
+
+    /* Initialized */
+    bool initialized;
 };
 
 static struct serial_dev_priv serial_dev_priv = {
@@ -37,69 +77,215 @@ static struct serial_dev_priv serial_dev_priv = {
     .mcr = UART_MCR_OUT2,
     .lsr = UART_LSR_TEMT | UART_LSR_THRE,
     .msr = UART_MSR_DCD | UART_MSR_DSR | UART_MSR_CTS,
+    .rxtrig = 1,
 };
+
+static void serial_signal(serial_dev_t *s)
+{
+    struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
+    uint64_t buf = 1;
+    if (write(priv->evfd, &buf, 8) < 0)
+        throw_err("Failed to write to eventfd\n");
+}
 
 /* FIXME: This implementation is incomplete */
 static void serial_update_irq(serial_dev_t *s)
 {
     struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
     uint8_t iir = UART_IIR_NO_INT;
+    uint8_t oiir = priv->iir;
 
+    if ((priv->ier & UART_IER_RLSI) && (priv->lsr & UART_LSR_BRK_ERROR_BITS))
+        iir = UART_IIR_RLSI;
     /* If enable receiver data interrupt and receiver data ready */
-    if ((priv->ier & UART_IER_RDI) && (priv->lsr & UART_LSR_DR))
-        iir = UART_IIR_RDI;
+    else if ((priv->ier & UART_IER_RDI) && (priv->lsr & UART_LSR_DR))
+        iir = fifo_level(&priv->rx_buf) < priv->rxtrig ? UART_IIR_RX_TIMEOUT
+                                                       : UART_IIR_RDI;
     /* If enable transmiter data interrupt and transmiter empty */
-    else if ((priv->ier & UART_IER_THRI) && (priv->lsr & UART_LSR_TEMT))
+    else if ((priv->ier & UART_IER_THRI) && (priv->lsr & UART_LSR_THRE) &&
+             priv->thr_ipending)
         iir = UART_IIR_THRI;
+    else if ((priv->msr & UART_MSR_ANY_DELTA) && (priv->ier & UART_IER_MSI))
+        iir = UART_IIR_MSI;
 
-    priv->iir = iir | 0xc0;
+    if (priv->fcr & UART_FCR_ENABLE_FIFO)
+        iir |= 0xc0;
 
-    /* FIXME: the return error of vm_irq_line should be handled */
-    vm_irq_line(container_of(s, vm_t, serial), SERIAL_IRQ,
-                iir == UART_IIR_NO_INT ? 0 /* inactive */ : 1 /* active */);
+    __atomic_store_n(&priv->iir, iir, __ATOMIC_RELEASE);
+
+    if ((oiir & UART_IIR_NO_INT) != (iir & UART_IIR_NO_INT)) {
+        /* FIXME: the return error of vm_irq_line should be handled */
+        vm_irq_line(container_of(s, vm_t, serial), SERIAL_IRQ,
+                    !(iir & UART_IIR_NO_INT));
+    }
 }
 
-static int serial_readable(serial_dev_t *s, int timeout)
+/* Read from stdin and write the data to rx_buf */
+static void serial_receive(serial_dev_t *s)
 {
-    struct pollfd pollfd = (struct pollfd){
-        .fd = s->infd,
-        .events = POLLIN,
-    };
-    return (poll(&pollfd, 1, timeout) > 0) && (pollfd.revents & POLLIN);
+    struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
+    struct iovec iov[2];
+    int iovc;
+
+    if (fifo_is_full(&priv->rx_buf))
+        return;
+
+    /* Transfer data from infd to rx_buf */
+    int head = (priv->rx_buf.head - 1) % FIFO_LEN + 1;
+    int tail = priv->rx_buf.tail % FIFO_LEN;
+    uint8_t *buf = priv->rx_buf.data;
+    int len;
+    if (tail < head) {
+        iov[0].iov_base = &buf[tail];
+        iov[0].iov_len = head - tail;
+        iovc = 1;
+    } else {
+        iov[0].iov_base = &buf[head];
+        iov[0].iov_len = FIFO_LEN - tail;
+        iov[1].iov_base = buf;
+        iov[1].iov_len = head;
+        iovc = 2;
+    }
+    len = readv(priv->infd, iov, iovc);
+    if (len < 1)
+        return;
+    priv->rx_buf.tail += len;
+
+    /* Update registers */
+    pthread_mutex_lock(&priv->lock);
+    if (!fifo_is_empty(&priv->rx_buf)) {
+        priv->lsr |= UART_LSR_DR;
+        serial_update_irq(s);
+    }
+    pthread_mutex_unlock(&priv->lock);
 }
 
-#define FREQ_NS ((int) (1.0e6))
-#define NS_PER_SEC ((int) (1.0e9))
+/* Read from tx_buf and write the data to stdout */
+static void serial_transmit(serial_dev_t *s)
+{
+    struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
+    struct iovec iov[2];
+    int iovc;
+    if (fifo_is_empty(&priv->tx_buf))
+        return;
 
-/* global state to stop the loop of thread */
-static volatile bool thread_stop = false;
+    /* Transfer data from tx_buf to outfd */
+    int head = priv->tx_buf.head % FIFO_LEN;
+    int tail = (priv->tx_buf.tail - 1) % FIFO_LEN + 1;
+    uint8_t *buf = priv->tx_buf.data;
+    int len;
+    if (head < tail) {
+        iov[0].iov_base = &buf[head];
+        iov[0].iov_len = tail - head;
+        iovc = 1;
+    } else {
+        iov[0].iov_base = &buf[head];
+        iov[0].iov_len = FIFO_LEN - head;
+        iov[1].iov_base = buf;
+        iov[1].iov_len = tail;
+        iovc = 2;
+    }
+    len = writev(priv->outfd, iov, iovc);
+    if (len < 1)
+        return;
+    priv->tx_buf.head += len;
+
+    /* Update registers */
+    pthread_mutex_lock(&priv->lock);
+    if (fifo_is_empty(&priv->tx_buf)) {
+        uint8_t lsr = priv->lsr;
+        lsr |= UART_LSR_THRE | UART_LSR_TEMT;
+        __atomic_store_n(&priv->lsr, lsr, __ATOMIC_RELAXED);
+        priv->thr_ipending = true;
+        serial_update_irq(s);
+    }
+    pthread_mutex_unlock(&priv->lock);
+}
+
+static void serial_loopback(serial_dev_t *s)
+{
+    struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
+    uint8_t tmp;
+    /* Transfer data from tx_buf to rx_buf */
+    while (!fifo_is_empty(&priv->tx_buf) && !fifo_is_full(&priv->rx_buf)) {
+        if (!fifo_get(&priv->tx_buf, tmp))
+            break;
+        fifo_put(&priv->rx_buf, tmp);
+    }
+    if (!fifo_is_empty(&priv->tx_buf)) {
+        /* rx_buf overrun */
+        fifo_clear(&priv->tx_buf);
+        priv->lsr |= UART_LSR_OE;
+    }
+    if (fifo_is_empty(&priv->tx_buf))
+        priv->lsr |= UART_LSR_TEMT | UART_LSR_THRE;
+    if (!fifo_is_empty(&priv->rx_buf))
+        priv->lsr |= UART_LSR_DR;
+    serial_update_irq(s);
+}
 
 static void *serial_thread(serial_dev_t *s)
 {
-    while (!__atomic_load_n(&thread_stop, __ATOMIC_RELAXED)) {
-        if (serial_readable(s, -1))
-            pthread_kill((pthread_t) s->main_tid, SIGUSR1);
-    }
+    struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
+    int epollfd = priv->epollfd;
+    struct epoll_event event;
+    uint64_t tmp;
 
+    while (!__atomic_load_n(&priv->stopped, __ATOMIC_RELAXED)) {
+        int ret = epoll_wait(epollfd, &event, 1, -1);
+        if (ret < 1)
+            continue;
+        if (event.data.u32 == SERIAL_EPOLL_EVENT)
+            if (read(priv->evfd, &tmp, 8) < 0)
+                throw_err("Failed to read from eventfd\n");
+        pthread_mutex_lock(&priv->loopback_lock);
+        switch (event.data.u32) {
+        case SERIAL_EPOLL_EVENT:
+            serial_transmit(s);
+            serial_receive(s);
+        case SERIAL_EPOLL_OUT:
+            serial_transmit(s);
+        case SERIAL_EPOLL_IN:
+            serial_receive(s);
+            break;
+        }
+        pthread_mutex_unlock(&priv->loopback_lock);
+    }
     return NULL;
 }
 
-void serial_console(serial_dev_t *s)
+static void serial_set_trigger_level(serial_dev_t *s)
 {
     struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
-
-    if (priv->lsr & UART_LSR_DR || !fifo_is_empty(&priv->rx_buf))
+    const uint8_t trigs[] = SERIAL_TRIG_LEVELS;
+    if (!(priv->fcr & UART_FCR_ENABLE_FIFO)) {
+        priv->rxtrig = 1;
         return;
-
-    while (!fifo_is_full(&priv->rx_buf) && serial_readable(s, 0)) {
-        char c;
-        if (read(s->infd, &c, 1) == -1)
-            break;
-        if (!fifo_put(&priv->rx_buf, c))
-            break;
-        priv->lsr |= UART_LSR_DR;
     }
+    int trigbits = UART_FCR_R_TRIG_BITS(priv->fcr);
+    priv->rxtrig = trigs[trigbits];
+}
+
+static void serial_set_msr(serial_dev_t *s, uint8_t msr)
+{
+    struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
+    uint8_t omsr = priv->mcr;
+    msr &= UART_MSR_ANY_DELTA;
+    msr |= (omsr & UART_MSR_ANY_DELTA);
+
+    if ((msr & UART_MSR_DSR) != (omsr & UART_MSR_DSR))
+        msr |= UART_MSR_DDSR;
+    if ((msr & UART_MSR_CTS) != (omsr & UART_MSR_CTS))
+        msr |= UART_MSR_DCTS;
+    if (!(msr & UART_MSR_RI) && (omsr & UART_MSR_RI))
+        msr |= UART_MSR_RI;
+    if ((msr & UART_MSR_DCD) != (omsr & UART_MSR_DCD))
+        msr |= UART_MSR_DDCD;
+
+    pthread_mutex_lock(&priv->lock);
+    priv->msr = msr;
     serial_update_irq(s);
+    pthread_mutex_unlock(&priv->lock);
 }
 
 static void serial_in(serial_dev_t *s, uint16_t offset, void *data)
@@ -110,19 +296,26 @@ static void serial_in(serial_dev_t *s, uint16_t offset, void *data)
     case UART_RX:
         if (priv->lcr & UART_LCR_DLAB) {
             IO_WRITE8(data, priv->dll);
-        } else {
-            if (fifo_is_empty(&priv->rx_buf))
-                break;
-
-            uint8_t value;
-            if (fifo_get(&priv->rx_buf, value))
-                IO_WRITE8(data, value);
-
-            if (fifo_is_empty(&priv->rx_buf)) {
-                priv->lsr &= ~UART_LSR_DR;
-                serial_update_irq(s);
-            }
+            return;
         }
+
+        uint8_t value;
+        if (!fifo_get(&priv->rx_buf, value))
+            return;
+        IO_WRITE8(data, value);
+
+        int level = fifo_level(&priv->rx_buf);
+        if (level == 0 || level == priv->rxtrig - 1) {
+            pthread_mutex_lock(&priv->lock);
+            /* check again the fifo level before modify the register */
+            level = fifo_level(&priv->rx_buf);
+            if (level == 0)
+                priv->lsr &= ~UART_LSR_DR;
+            serial_update_irq(s);
+            pthread_mutex_unlock(&priv->lock);
+        }
+        if (level == FIFO_LEN - 1)
+            serial_signal(s);
         break;
     case UART_IER:
         if (priv->lcr & UART_LCR_DLAB)
@@ -131,7 +324,16 @@ static void serial_in(serial_dev_t *s, uint16_t offset, void *data)
             IO_WRITE8(data, priv->ier);
         break;
     case UART_IIR:
-        IO_WRITE8(data, priv->iir | 0xc0); /* 0xc0 stands for FIFO enabled */
+        uint8_t iir = __atomic_load_n(&priv->iir, __ATOMIC_ACQUIRE);
+        IO_WRITE8(data, iir);
+        if ((iir & UART_IIR_ID) == UART_IIR_THRI) {
+            /* The spec says that the THR empty interrupt should be clear after
+             * IIR is read */
+            pthread_mutex_lock(&priv->lock);
+            priv->thr_ipending = false;
+            serial_update_irq(s);
+            pthread_mutex_unlock(&priv->lock);
+        }
         break;
     case UART_LCR:
         IO_WRITE8(data, priv->lcr);
@@ -140,10 +342,25 @@ static void serial_in(serial_dev_t *s, uint16_t offset, void *data)
         IO_WRITE8(data, priv->mcr);
         break;
     case UART_LSR:
-        IO_WRITE8(data, priv->lsr);
+        uint8_t lsr = __atomic_load_n(&priv->lsr, __ATOMIC_RELAXED);
+        IO_WRITE8(data, lsr);
+        if (lsr & UART_LSR_BRK_ERROR_BITS) {
+            /* clear error bits */
+            pthread_mutex_lock(&priv->lock);
+            priv->lsr &= ~UART_LSR_BRK_ERROR_BITS;
+            serial_update_irq(s);
+            pthread_mutex_unlock(&priv->lock);
+        }
         break;
     case UART_MSR:
         IO_WRITE8(data, priv->msr);
+        if (priv->msr & UART_MSR_ANY_DELTA) {
+            /* clear delta bits */
+            pthread_mutex_lock(&priv->lock);
+            priv->msr &= ~UART_MSR_ANY_DELTA;
+            serial_update_irq(s);
+            pthread_mutex_unlock(&priv->lock);
+        }
         break;
     case UART_SCR:
         IO_WRITE8(data, priv->scr);
@@ -156,34 +373,88 @@ static void serial_in(serial_dev_t *s, uint16_t offset, void *data)
 static void serial_out(serial_dev_t *s, uint16_t offset, void *data)
 {
     struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
-
+    uint8_t orig, value;
     switch (offset) {
     case UART_TX:
         if (priv->lcr & UART_LCR_DLAB) {
             priv->dll = IO_READ8(data);
-        } else {
-            priv->lsr |= (UART_LSR_TEMT | UART_LSR_THRE); /* flush TX */
-            putchar(((char *) data)[0]);
-            fflush(stdout);
-            serial_update_irq(s);
+            return;
         }
+        if (!fifo_put(&priv->tx_buf, IO_READ8(data)))
+            break;
+        if (priv->mcr & UART_MCR_LOOP) {
+            /* Loopback mode, drain tx */
+            serial_loopback(s);
+            break;
+        }
+        int level = fifo_level(&priv->tx_buf);
+        if (level == 1) {
+            pthread_mutex_lock(&priv->lock);
+            /* check again the fifo level before modify any registers */
+            level = fifo_level(&priv->tx_buf);
+            if (level == 1) {
+                priv->lsr &= ~(UART_LSR_TEMT | UART_LSR_THRE);
+                serial_update_irq(s);
+            }
+            pthread_mutex_unlock(&priv->lock);
+        }
+        if (level == 1)
+            serial_signal(s);
         break;
     case UART_IER:
         if (!(priv->lcr & UART_LCR_DLAB)) {
-            priv->ier = IO_READ8(data);
+            pthread_mutex_lock(&priv->lock);
+            priv->ier = IO_READ8(data) & IER_MASK;
             serial_update_irq(s);
+            pthread_mutex_unlock(&priv->lock);
         } else {
             priv->dlm = IO_READ8(data);
         }
         break;
     case UART_FCR:
-        priv->fcr = IO_READ8(data);
+        value = IO_READ8(data);
+        pthread_mutex_lock(&priv->lock);
+        priv->fcr = value & FCR_MASK;
+        if (value & UART_FCR_CLEAR_RCVR) {
+            /* Clear receive buffer */
+            fifo_clear(&priv->rx_buf);
+            priv->lsr &= ~UART_LSR_DR;
+        }
+        if (value & UART_FCR_CLEAR_XMIT) {
+            /* Clear transmit buffer */
+            fifo_clear(&priv->tx_buf);
+            priv->lsr |= UART_LSR_TEMT | UART_LSR_THRE;
+            priv->thr_ipending = true;
+        }
+        serial_set_trigger_level(s);
+        serial_update_irq(s);
+        pthread_mutex_unlock(&priv->lock);
         break;
     case UART_LCR:
         priv->lcr = IO_READ8(data);
         break;
     case UART_MCR:
-        priv->mcr = IO_READ8(data);
+        orig = priv->mcr;
+        value = IO_READ8(data);
+        priv->mcr = value & MCR_MASK;
+        if ((orig & UART_MCR_LOOP) && !(value & UART_MCR_LOOP)) {
+            /* Leave the loopback mode */
+            serial_set_msr(s, DEFAULT_MSR);
+            pthread_mutex_unlock(&priv->loopback_lock);
+        }
+        if (!(orig & UART_MCR_LOOP) && (value & UART_MCR_LOOP)) {
+            /* Enter the loopback mode */
+            pthread_mutex_lock(&priv->loopback_lock);
+            serial_loopback(s);
+        }
+        if (value & UART_MCR_LOOP) {
+            /* In loopback mode, the output pins are wired to the input pins */
+            uint8_t msr;
+            msr = (value & 0xc0U) << 4;
+            msr |= (value & 0x02U) << 3;
+            msr |= (value & 0x01U) << 5;
+            serial_set_msr(s, msr);
+        }
         break;
     case UART_LSR: /* factory test */
     case UART_MSR: /* not used */
@@ -210,44 +481,108 @@ static void serial_handle_io(void *owner,
     serial_op(s, offset, data);
 }
 
-static void handler(int sig, siginfo_t *si, void *uc) {}
-
 int serial_init(serial_dev_t *s, struct bus *bus)
 {
-    sigset_t mask;
+    struct serial_dev_priv *priv = &serial_dev_priv;
+    struct epoll_event event;
 
-    struct sigaction sa = {.sa_flags = SA_SIGINFO, .sa_sigaction = handler};
-    sigemptyset(&sa.sa_mask);
-    if (sigaction(SIGUSR1, &sa, NULL) == -1)
-        return throw_err("Failed to create signal handler");
+    if (priv->initialized)
+        return throw_err("Serial device is already initialized\n");
 
-    /* Block timer signal temporarily. */
-    sigemptyset(&mask);
-    sigaddset(&mask, SIGUSR1);
-    if (sigprocmask(SIG_SETMASK, &mask, NULL) == -1)
-        return throw_err("Failed to block timer signal");
+    s->priv = &serial_dev_priv;
 
-    *s = (serial_dev_t){
-        .priv = (void *) &serial_dev_priv,
-        .main_tid = pthread_self(),
-        .infd = STDIN_FILENO,
-    };
-    pthread_create(&s->worker_tid, NULL, (void *) serial_thread, (void *) s);
+    /* Create necessory file descriptors */
+    int evfd, infd, outfd, epollfd;
+    evfd = infd = outfd = epollfd = -1;
 
-    /* Unlock the timer signal, so that timer notification
-     * can be delivered.
-     */
-    if (sigprocmask(SIG_UNBLOCK, &mask, NULL) == -1)
-        return throw_err("Failed to unblock timer signal");
+    evfd = eventfd(0, EFD_NONBLOCK);
+    if (evfd < 0) {
+        throw_err("Failed to create eventfd\n");
+        goto err;
+    }
+    infd = open("/dev/stdin", O_RDONLY | O_NONBLOCK);
+    if (infd < 0) {
+        throw_err("Failed to open stdin device\n");
+        goto err;
+    }
+    outfd = open("/dev/stdout", O_WRONLY | O_NONBLOCK);
+    if (outfd < 0) {
+        throw_err("Failed to open stdout device\n");
+        goto err;
+    }
+    epollfd = epoll_create1(0);
+    if (epollfd < 0) {
+        throw_err("Failed to create epoll file descriptor\n");
+        goto err;
+    }
+
+    priv->evfd = evfd;
+    priv->infd = infd;
+    priv->outfd = outfd;
+    priv->epollfd = epollfd;
+
+    /* Setup epoll */
+    event.events = EPOLLIN;
+    event.data.u32 = SERIAL_EPOLL_EVENT;
+    if (epoll_ctl(epollfd, EPOLL_CTL_ADD, evfd, &event) < 0) {
+        throw_err("Failed to add eventfd to epoll\n");
+        goto err;
+    }
+    event.events = EPOLLIN | EPOLLET;
+    event.data.u32 = SERIAL_EPOLL_IN;
+    if (epoll_ctl(epollfd, EPOLL_CTL_ADD, infd, &event) < 0) {
+        throw_err("Failed to add stdin to epoll\n");
+        goto err;
+    }
+    event.events = EPOLLOUT | EPOLLET;
+    event.data.u32 = SERIAL_EPOLL_OUT;
+    if (epoll_ctl(epollfd, EPOLL_CTL_ADD, outfd, &event) < 0) {
+        if (errno != EPERM) {
+            throw_err("Failed to add stdout to epoll\n");
+            goto err;
+        }
+    }
+
+    /* Setup mutex */
+    pthread_mutex_init(&priv->lock, NULL);
+    pthread_mutex_init(&priv->loopback_lock, NULL);
+
+    /* Create the thread*/
+    priv->stopped = false;
+    if (pthread_create(&priv->worker, NULL, (void *) serial_thread,
+                       (void *) s) < 0) {
+        throw_err("Failed to create worker thread\n");
+        goto err;
+    }
 
     dev_init(&s->dev, COM1_PORT_BASE, COM1_PORT_SIZE, s, serial_handle_io);
     bus_register_dev(bus, &s->dev);
 
+    priv->initialized = true;
+
     return 0;
+
+err:
+    close(infd);
+    close(outfd);
+    close(evfd);
+    close(epollfd);
+
+    return -1;
 }
 
 void serial_exit(serial_dev_t *s)
 {
-    __atomic_store_n(&thread_stop, true, __ATOMIC_RELAXED);
-    pthread_join(s->worker_tid, NULL);
+    struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
+    __atomic_store_n(&priv->stopped, true, __ATOMIC_RELAXED);
+    pthread_join(priv->worker, NULL);
+
+    /* If exiting in the loop back mode, unlock the lookback lock. */
+    if (priv->mcr & UART_MCR_LOOP)
+        pthread_mutex_unlock(&priv->loopback_lock);
+
+    close(priv->evfd);
+    close(priv->infd);
+    close(priv->outfd);
+    close(priv->epollfd);
 }

--- a/src/serial.h
+++ b/src/serial.h
@@ -11,8 +11,6 @@ typedef struct serial_dev serial_dev_t;
 
 struct serial_dev {
     void *priv;
-    pthread_t main_tid, worker_tid;
-    int infd; /* file descriptor for serial input */
     struct dev dev;
 };
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,5 +1,4 @@
-#ifndef UTILS_H
-#define UTILS_H
+#pragma once
 
 #define container_of(ptr, type, member)               \
     ({                                                \
@@ -12,12 +11,19 @@
 
 struct fifo {
     uint8_t data[FIFO_LEN];
-    unsigned int head, tail;
+    _Atomic unsigned int head, tail;
 };
 
 #define fifo_is_empty(fifo) ((fifo)->head == (fifo)->tail)
 
 #define fifo_is_full(fifo) ((fifo)->tail - (fifo)->head > FIFO_MASK)
+
+#define fifo_level(fifo) ((fifo)->tail - (fifo)->head)
+
+#define fifo_clear(fifo)             \
+    do {                             \
+        (fifo)->head = (fifo)->tail; \
+    } while (0)
 
 #define fifo_put(fifo, value)                               \
     ({                                                      \
@@ -38,5 +44,3 @@ struct fifo {
         }                                                   \
         __ret;                                              \
     })
-
-#endif

--- a/src/vm.c
+++ b/src/vm.c
@@ -255,7 +255,6 @@ int vm_run(vm_t *v)
             vm_handle_mmio(v, run);
             break;
         case KVM_EXIT_INTR:
-            serial_console(&v->serial);
             break;
         case KVM_EXIT_SHUTDOWN:
             printf("shutdown\n");


### PR DESCRIPTION
After this change, the I/O handler called during VM exit will only need to deal with the FIFO buffers on the device. The work to interact with the terminal is offloaded to the worker thread.

The main thread use eventfd to signal the worker thread. The worker thread uses epoll to monitor stdin, stdout and the eventfd and will be notified when the state of one of these file descriptors change and perform the I/O when necessary.

Besides changing the original implementation to use eventfd and epoll, I also make the emulated device hehave more like a physical device. The notable change is that the loopback mode is implemented.