### PR TITLE
Make IRQ number of serial device changable

### DIFF
--- a/src/serial.c
+++ b/src/serial.c
@@ -55,7 +55,7 @@ static void serial_update_irq(serial_dev_t *s)
     priv->iir = iir | 0xc0;
 
     /* FIXME: the return error of vm_irq_line should be handled */
-    vm_irq_line(container_of(s, vm_t, serial), SERIAL_IRQ,
+    vm_irq_line(container_of(s, vm_t, serial), s->irq_num,
                 iir == UART_IIR_NO_INT ? 0 /* inactive */ : 1 /* active */);
 }
 
@@ -231,6 +231,7 @@ int serial_init(serial_dev_t *s, struct bus *bus)
         .priv = (void *) &serial_dev_priv,
         .main_tid = pthread_self(),
         .infd = STDIN_FILENO,
+        .irq_num = SERIAL_IRQ,
     };
     pthread_create(&s->worker_tid, NULL, (void *) serial_thread, (void *) s);
 

--- a/src/serial.h
+++ b/src/serial.h
@@ -14,6 +14,7 @@ struct serial_dev {
     pthread_t main_tid, worker_tid;
     int infd; /* file descriptor for serial input */
     struct dev dev;
+    int irq_num;
 };
 
 void serial_console(serial_dev_t *s);


### PR DESCRIPTION
Instead of using hard-coded IRQ number in the serial device, make it changable.

The IRQ number in serial.c is only valid for x86-64 architecture. When porting kvm-host to other architecture, it should provide a way for architecture specific initialization routine to change the IRQ number.