### PR TITLE
Add PCI MMIO device

### DIFF
--- a/src/pci.c
+++ b/src/pci.c
@@ -117,6 +117,8 @@ static void pci_config_do_io(void *owner,
         pci_config_read(dev, data, offset, size);
 }
 
+#define PCI_ADDR_ENABLE_BIT (1UL << 31)
+
 static void pci_data_io(void *owner,
                         void *data,
                         uint8_t is_write,
@@ -124,8 +126,20 @@ static void pci_data_io(void *owner,
                         uint8_t size)
 {
     struct pci *pci = (struct pci *) owner;
-    uint64_t addr = pci->pci_addr.value | offset;
-    bus_handle_io(&pci->pci_bus, data, is_write, addr, size);
+    if (pci->pci_addr.enable_bit) {
+        uint64_t addr = (pci->pci_addr.value | offset) & ~(PCI_ADDR_ENABLE_BIT);
+        bus_handle_io(&pci->pci_bus, data, is_write, addr, size);
+    }
+}
+
+static void pci_mmio_io(void *owner,
+                        void *data,
+                        uint8_t is_write,
+                        uint64_t offset,
+                        uint8_t size)
+{
+    struct pci *pci = (struct pci *) owner;
+    bus_handle_io(&pci->pci_bus, data, is_write, offset, size);
 }
 
 void pci_set_bar(struct pci_dev *dev,
@@ -163,8 +177,7 @@ void pci_dev_register(struct pci_dev *dev)
 {
     /* FIXEME: It just simplifies the registration on pci bus 0 */
     /* FIXEME: dev_num might exceed 32 */
-    union pci_config_address addr = {.enable_bit = 1,
-                                     .dev_num = dev->pci_bus->dev_num};
+    union pci_config_address addr = {.dev_num = dev->pci_bus->dev_num};
     dev_init(&dev->config_dev, addr.value, PCI_CFG_SPACE_SIZE, dev,
              pci_config_do_io);
     bus_register_dev(dev->pci_bus, &dev->config_dev);
@@ -172,6 +185,7 @@ void pci_dev_register(struct pci_dev *dev)
 
 #define PCI_CONFIG_ADDR 0xCF8
 #define PCI_CONFIG_DATA 0xCFC
+#define PCI_MMIO_SIZE (1UL << 16)
 
 void pci_init(struct pci *pci)
 {
@@ -179,5 +193,6 @@ void pci_init(struct pci *pci)
              pci_address_io);
     dev_init(&pci->pci_bus_dev, PCI_CONFIG_DATA, sizeof(uint32_t), pci,
              pci_data_io);
+    dev_init(&pci->pci_mmio_dev, 0, PCI_MMIO_SIZE, pci, pci_mmio_io);
     bus_init(&pci->pci_bus);
 }

--- a/src/pci.h
+++ b/src/pci.h
@@ -42,6 +42,7 @@ struct pci {
     struct bus pci_bus;
     struct dev pci_bus_dev;
     struct dev pci_addr_dev;
+    struct dev pci_mmio_dev;
 };
 
 void pci_set_bar(struct pci_dev *dev,


### PR DESCRIPTION
On some platforms, PCI configuration space is accessed by using MMIO.

This change adds pci_mmio_dev to struct pci. Architecture specific initialization routines can register this device to mmio_bus to enable MMIO access for PCI configuration space.