### PR TITLE
Refine FIFO operations of serial device

### DIFF
--- a/src/serial.h
+++ b/src/serial.h
@@ -11,7 +11,7 @@ typedef struct serial_dev serial_dev_t;
 
 struct serial_dev {
     void *priv;
-    pthread_t main_tid, worker_tid;
+    pthread_t worker_tid;
     int infd; /* file descriptor for serial input */
     struct dev dev;
     int irq_num;

--- a/src/utils.h
+++ b/src/utils.h
@@ -19,6 +19,8 @@ struct fifo {
 
 #define fifo_is_full(fifo) ((fifo)->tail - (fifo)->head > FIFO_MASK)
 
+#define fifo_capacity(fifo) ((fifo)->tail - (fifo)->head)
+
 #define fifo_put(fifo, value)                               \
     ({                                                      \
         unsigned int __ret = !fifo_is_full(fifo);           \

--- a/src/vm.c
+++ b/src/vm.c
@@ -135,7 +135,6 @@ int vm_run(vm_t *v)
             vm_handle_mmio(v, run);
             break;
         case KVM_EXIT_INTR:
-            serial_console(&v->serial);
             break;
         case KVM_EXIT_SHUTDOWN:
             printf("shutdown\n");


### PR DESCRIPTION
Instead of sending signal to notify the main thread to read more bytes into rx_buf, just do it in the worker thread.

When rx_buf is full and the worker thread cannot load more bytes, wait on the condition variable. The main thread will wake the worker thread when the level of the rx_buf decreases to its half size.

Since multiple threads can access the internal structure of the serial device, use a mutex to protect it.

It should be pushed to the original pull request #16, but it is closed when I renamed the branch. I did not find a way to reopen it, so I submit a new pull request.