### PR TITLE
Import part of libfdt library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "src/dtc"]
+	path = src/dtc
+	url = https://git.kernel.org/pub/scm/utils/dtc/dtc.git
+	branch = v1.7.0

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,13 @@ BIN = $(OUT)/kvm-host
 
 all: $(BIN)
 
+FDT_OBJS := \
+	dtc/libfdt/fdt.o \
+	dtc/libfdt/fdt_sw.o \
+	dtc/libfdt/fdt_strerror.o
+
+FDT_CFLAGS := -Isrc/dtc/libfdt
+
 OBJS := \
 	vm.o \
 	serial.o \


### PR DESCRIPTION
The arm64 Linux boot protocol requires bootloaders to pass a device tree to the kernel. We import part of the libfdt library that can be used to generate flatten device trees required by the kernel.

The license of libfdt is GPLv2 or BSD 2 clause, which is compatible with this project. It should be ok to impoprt it directly.

The version of libfdt being imported is 1.7.0.

I do not know whether it is better to import this library directly, or we could just ask the user to install the package, libfdt-dev, before compiling this project. 