### PR TITLE
Handle Ctrl-a x sequence to exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ containing concatenated `bootsect.o + setup.o + misc.o + piggy.o`. `initrd` is t
 initial RAM disk image, which is an optional argument.
 `disk-image` is the path to disk image which can be mounted as a block device via virtio. For the reference Linux guest, ext4 filesystem is used for disk image.
 
+To exit kvm-host, press "Ctrl-A", release both keys, and then press "x".
+
 ## License
 
 `kvm-host` is released under the BSD 2 clause license. Use of this source code is governed by

--- a/src/main.c
+++ b/src/main.c
@@ -42,7 +42,7 @@ static void set_input_mode(void)
     atexit(reset_input_mode);
 
     tattr = saved_attributes;
-    tattr.c_lflag &= ~(ICANON | ECHO);
+    tattr.c_lflag &= ~(ICANON | ECHO | ISIG);
     tcsetattr(STDIN_FILENO, TCSANOW, &tattr);
 }
 


### PR DESCRIPTION
Originally, the guest will be terminated when ctrl-c is pressed. This causes the guest to exit unexpectedly.

This change addresses this issue by removing ISIG flag in c_lflag in termios and adds a key sequence ctrl-a x to terminate the guest.
