### PR TITLE
Remove internal rootfs target from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,6 @@ make build/bzImage
 ```
 (or `make build/Image` for Arm64 host)
 
-Download and build Busybox for root file system from scratch:
-```shell
-make rootfs
-```
-
 Run Linux guest with `kvm-host`:
 ```shell
 make check


### PR DESCRIPTION
The "rootfs" target was originally introduced in commit 9d5eac5: "Parse the cmdline arguments more perfectly", but was later removed in commit 25571f7: "Modularize the build system" without updates to the README or integration into mk/external.mk.

"make rootfs" is considered redundant, since the target is only intended to used internally, this commit removes its description in README to prevent confusion.