### PR TITLE
Bump CI to ubuntu-24.04 and clang-format-20

### DIFF
--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -2,13 +2,16 @@
 
 set -e -u -o pipefail
 
-SOURCES=$(find $(git rev-parse --show-toplevel) | egrep "\.(c|cxx|cpp|h|hpp)\$")
+cd "$(git rev-parse --show-toplevel)"
 
 set -x
 
-for file in ${SOURCES};
-do
-    clang-format-12 ${file} > expected-format
-    diff -u -p --label="${file}" --label="expected coding style" ${file} expected-format
-done
-exit $(clang-format-12 --output-replacements-xml ${SOURCES} | egrep -c "</replacement>")
+while IFS= read -r -d '' file; do
+    clang-format-20 "$file" > expected-format
+    diff -u -p --label="$file" --label="expected coding style" "$file" expected-format
+done < <(git ls-files -z '*.c' '*.cxx' '*.cpp' '*.h' '*.hpp')
+
+count=$(git ls-files -z '*.c' '*.cxx' '*.cpp' '*.h' '*.hpp' \
+    | xargs -0 clang-format-20 --output-replacements-xml \
+    | grep -c "</replacement>" || true)
+exit "$count"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,15 +4,15 @@ on: [push, pull_request]
 
 jobs:
   detect-code-related-file-changes:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       has_code_related_changes: ${{ steps.set_has_code_related_changes.outputs.has_code_related_changes }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Test changed files
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@v47
         with:
           files: |
               .ci/**
@@ -33,21 +33,30 @@ jobs:
   host-x64:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: default build
       run: make
 
   coding-style:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
+    - name: Install clang-format-20
+      run: |
+            sudo install -m 0755 -d /etc/apt/keyrings
+            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+                | sudo gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
+            echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" \
+                | sudo tee /etc/apt/sources.list.d/llvm.list
+            sudo apt-get update
+            sudo apt-get install -q -y clang-format-20
+      shell: bash
     - name: coding convention
       run: |
-            sudo apt-get install -q -y clang-format-12
             .ci/check-newline.sh
             .ci/check-format.sh
       shell: bash

--- a/src/arch/x86/vm.c
+++ b/src/arch/x86/vm.c
@@ -69,8 +69,11 @@ static void vm_init_cpu_id(vm_t *v)
 #define MSR_IA32_MISC_ENABLE_FAST_STRING \
     (1ULL << MSR_IA32_MISC_ENABLE_FAST_STRING_BIT)
 
-#define KVM_MSR_ENTRY(_index, _data) \
-    (struct kvm_msr_entry) { .index = _index, .data = _data }
+#define KVM_MSR_ENTRY(_index, _data)   \
+    (struct kvm_msr_entry)             \
+    {                                  \
+        .index = _index, .data = _data \
+    }
 static void vm_init_msrs(vm_t *v)
 {
     int ndx = 0;
@@ -155,12 +158,12 @@ int vm_arch_load_image(vm_t *v, void *data, size_t datasz)
 
     /* setup E820 memory map to report usable address ranges for initrd */
     unsigned int idx = 0;
-    boot->e820_table[idx++] = (struct boot_e820_entry){
+    boot->e820_table[idx++] = (struct boot_e820_entry) {
         .addr = 0x0,
         .size = ISA_START_ADDRESS - 1,
         .type = E820_RAM,
     };
-    boot->e820_table[idx++] = (struct boot_e820_entry){
+    boot->e820_table[idx++] = (struct boot_e820_entry) {
         .addr = ISA_END_ADDRESS,
         .size = RAM_SIZE - ISA_END_ADDRESS,
         .type = E820_RAM,

--- a/src/serial.c
+++ b/src/serial.c
@@ -64,7 +64,7 @@ static void serial_update_irq(serial_dev_t *s)
 
 static int serial_readable(serial_dev_t *s, int timeout)
 {
-    struct pollfd pollfd = (struct pollfd){
+    struct pollfd pollfd = (struct pollfd) {
         .fd = s->infd,
         .events = POLLIN,
     };
@@ -246,7 +246,7 @@ static void serial_handle_io(void *owner,
 
 int serial_init(serial_dev_t *s, struct bus *bus)
 {
-    *s = (serial_dev_t){
+    *s = (serial_dev_t) {
         .priv = (void *) &serial_dev_priv,
         .infd = STDIN_FILENO,
         .irq_num = SERIAL_IRQ,

--- a/src/virtio-blk.c
+++ b/src/virtio-blk.c
@@ -23,7 +23,7 @@ static void virtio_blk_notify_used(struct virtq *vq)
 
 static int virtio_blk_virtq_available(struct virtio_blk_dev *dev, int timeout)
 {
-    struct pollfd pollfd = (struct pollfd){
+    struct pollfd pollfd = (struct pollfd) {
         .fd = dev->ioeventfd,
         .events = POLLIN,
     };

--- a/src/virtio-net.c
+++ b/src/virtio-net.c
@@ -29,7 +29,7 @@ static volatile bool thread_stop = false;
 static int virtio_net_virtq_available_rx(struct virtio_net_dev *dev,
                                          int timeout)
 {
-    struct pollfd pollfd = (struct pollfd){
+    struct pollfd pollfd = (struct pollfd) {
         .fd = dev->tapfd,
         .events = POLLIN,
     };

--- a/src/virtio-pci.c
+++ b/src/virtio-pci.c
@@ -173,7 +173,7 @@ static void virtio_pci_set_cap(struct virtio_pci_dev *dev, uint8_t next)
     for (int i = 1; i < VIRTIO_PCI_CAP_NUM + 1; i++) {
         caps[i] =
             (struct virtio_pci_cap *) ((uintptr_t) dev->pci_dev.hdr + next);
-        *caps[i] = (struct virtio_pci_cap){
+        *caps[i] = (struct virtio_pci_cap) {
             .cap_vndr = PCI_CAP_ID_VNDR,
             .cfg_type = i,
             .cap_len = sizeof(struct virtio_pci_cap),


### PR DESCRIPTION
- Upgrade runner ubuntu-22.04 -> ubuntu-24.04.
- Upgrade actions/checkout v4 -> v6 and tj-actions/changed-files v44 -> v47.
- Install clang-format-20 from apt.llvm.org via a signed apt repository instead of piping the upstream installer through sudo bash.
- Rewrite .ci/check-format.sh to enumerate sources via 'git ls-files -z' (skips the src/dtc submodule and build artifacts, handles whitespace in paths) and guard `grep -c` against the zero-match exit-1 trap.