### PR TITLE
Harden virtio request paths and device shutdown

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ We welcome all contributions from corporate, academic and individual developers.
 * All code must adhere to the existing C coding style (see below). While we are somewhat flexible in basic style, you will adhere to what is currently in place. Uncommented, complicated algorithmic constructs will be rejected.
 * All external pull requests must contain sufficient documentation in the pull request comments in order to be accepted.
 
-Software requirement: [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 12 or later.
+Software requirement: [clang-format](https://clang.llvm.org/docs/ClangFormat.html) version 20 or later.
 
 Use the command `$ clang-format -i *.[ch]` to enforce a consistent coding style.
 

--- a/src/arch/x86/vm.c
+++ b/src/arch/x86/vm.c
@@ -160,7 +160,7 @@ int vm_arch_load_image(vm_t *v, void *data, size_t datasz)
     unsigned int idx = 0;
     boot->e820_table[idx++] = (struct boot_e820_entry) {
         .addr = 0x0,
-        .size = ISA_START_ADDRESS - 1,
+        .size = ISA_START_ADDRESS,
         .type = E820_RAM,
     };
     boot->e820_table[idx++] = (struct boot_e820_entry) {

--- a/src/main.c
+++ b/src/main.c
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
             break;
         case 'h':
             usage(argv[0]);
-            exit(123);
+            exit(0);
         default:
             break;
         }

--- a/src/serial.c
+++ b/src/serial.c
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/eventfd.h>
 #include <unistd.h>
 
 #include "err.h"
@@ -64,22 +65,23 @@ static void serial_update_irq(serial_dev_t *s)
 
 static int serial_readable(serial_dev_t *s, int timeout)
 {
-    struct pollfd pollfd = (struct pollfd) {
-        .fd = s->infd,
-        .events = POLLIN,
+    struct pollfd pollfds[] = {
+        [0] = {.fd = s->infd, .events = POLLIN},
+        [1] = {.fd = s->stopfd, .events = POLLIN},
     };
-    return (poll(&pollfd, 1, timeout) > 0) && (pollfd.revents & POLLIN);
-}
 
-/* global state to stop the loop of thread */
-static volatile bool thread_stop = false;
+    int ret = poll(pollfds, 2, timeout);
+
+    return ret > 0 && (pollfds[0].revents & POLLIN) &&
+           !(pollfds[1].revents & POLLIN);
+}
 
 static void *serial_thread(serial_dev_t *s)
 {
     struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
-    while (!__atomic_load_n(&thread_stop, __ATOMIC_RELAXED)) {
+    while (1) {
         if (!serial_readable(s, -1))
-            continue;
+            break;
         pthread_mutex_lock(&priv->lock);
         if (fifo_is_full(&priv->rx_buf)) {
             /* stdin is readable, but the rx_buf is full.
@@ -170,7 +172,7 @@ static void serial_in(serial_dev_t *s, uint16_t offset, void *data)
         break;
     case UART_LSR:
         value = __atomic_load_n(&priv->lsr, __ATOMIC_ACQUIRE);
-        IO_WRITE8(data, priv->lsr);
+        IO_WRITE8(data, value);
         break;
     case UART_MSR:
         IO_WRITE8(data, priv->msr);
@@ -249,8 +251,11 @@ int serial_init(serial_dev_t *s, struct bus *bus)
     *s = (serial_dev_t) {
         .priv = (void *) &serial_dev_priv,
         .infd = STDIN_FILENO,
+        .stopfd = eventfd(0, EFD_CLOEXEC),
         .irq_num = SERIAL_IRQ,
     };
+    if (s->stopfd < 0)
+        return throw_err("Failed to create serial stop eventfd");
     pthread_create(&s->worker_tid, NULL, (void *) serial_thread, (void *) s);
 
     dev_init(&s->dev, COM1_PORT_BASE, COM1_PORT_SIZE, s, serial_handle_io);
@@ -261,6 +266,15 @@ int serial_init(serial_dev_t *s, struct bus *bus)
 
 void serial_exit(serial_dev_t *s)
 {
-    __atomic_store_n(&thread_stop, true, __ATOMIC_RELAXED);
+    struct serial_dev_priv *priv = (struct serial_dev_priv *) s->priv;
+    uint64_t n = 1;
+
+    if (s->stopfd >= 0 && write(s->stopfd, &n, sizeof(n)) < 0)
+        throw_err("Failed to wake serial worker");
+    /* Worker may be parked in pthread_cond_wait when the rx FIFO is full;
+     * stopfd POLLIN alone won't wake it. Broadcast so it returns to the top
+     * of its loop and observes stopfd. */
+    pthread_cond_broadcast(&priv->cond);
     pthread_join(s->worker_tid, NULL);
+    close(s->stopfd);
 }

--- a/src/serial.h
+++ b/src/serial.h
@@ -13,6 +13,7 @@ struct serial_dev {
     void *priv;
     pthread_t worker_tid;
     int infd; /* file descriptor for serial input */
+    int stopfd;
     struct dev dev;
     int irq_num;
 };

--- a/src/virtio-blk.c
+++ b/src/virtio-blk.c
@@ -1,6 +1,5 @@
 #include <fcntl.h>
 #include <poll.h>
-#include <signal.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
@@ -23,23 +22,15 @@ static void virtio_blk_notify_used(struct virtq *vq)
 
 static int virtio_blk_virtq_available(struct virtio_blk_dev *dev, int timeout)
 {
-    struct pollfd pollfd = (struct pollfd) {
-        .fd = dev->ioeventfd,
-        .events = POLLIN,
+    struct pollfd pollfds[] = {
+        [0] = {.fd = dev->ioeventfd, .events = POLLIN},
+        [1] = {.fd = dev->stopfd, .events = POLLIN},
     };
-    return (poll(&pollfd, 1, timeout) > 0) && (pollfd.revents & POLLIN);
-}
 
-static volatile bool thread_stop = false;
+    int ret = poll(pollfds, 2, timeout);
 
-static void *virtio_blk_thread(struct virtio_blk_dev *dev)
-{
-    while (!__atomic_load_n(&thread_stop, __ATOMIC_RELAXED)) {
-        if (virtio_blk_virtq_available(dev, -1))
-            pthread_kill((pthread_t) dev->vq_avail_thread, SIGUSR1);
-    }
-
-    return NULL;
+    return ret > 0 && (pollfds[0].revents & POLLIN) &&
+           !(pollfds[1].revents & POLLIN);
 }
 
 static void *virtio_blk_vq_avail_handler(void *arg)
@@ -48,7 +39,9 @@ static void *virtio_blk_vq_avail_handler(void *arg)
     struct virtio_blk_dev *dev = (struct virtio_blk_dev *) vq->dev;
     uint64_t n;
 
-    while (read(dev->ioeventfd, &n, sizeof(n))) {
+    while (virtio_blk_virtq_available(dev, -1)) {
+        if (read(dev->ioeventfd, &n, sizeof(n)) < 0)
+            continue;
         virtq_handle_avail(vq);
     }
     return NULL;
@@ -72,8 +65,9 @@ static void virtio_blk_enable_vq(struct virtq *vq)
     uint64_t addr = virtio_pci_get_notify_addr(&dev->virtio_pci_dev, vq);
     vm_ioeventfd_register(v, dev->ioeventfd, addr,
                           dev->virtio_pci_dev.notify_cap->cap.length, 0);
-    pthread_create(&dev->vq_avail_thread, NULL, virtio_blk_vq_avail_handler,
-                   (void *) vq);
+    if (pthread_create(&dev->vq_avail_thread, NULL, virtio_blk_vq_avail_handler,
+                       (void *) vq) == 0)
+        dev->vq_thread_started = true;
 }
 
 static ssize_t virtio_blk_write(struct virtio_blk_dev *dev,
@@ -100,27 +94,36 @@ static void virtio_blk_complete_request(struct virtq *vq)
     struct vring_packed_desc *desc;
     struct virtio_blk_req req;
 
+    /* Wire-format header is type/reserved/sector only; the rest of struct
+     * virtio_blk_req is host bookkeeping and must not be overwritten by the
+     * guest. */
+    const size_t hdr_sz = offsetof(struct virtio_blk_req, data);
+
     while ((desc = virtq_get_avail(vq))) {
         struct vring_packed_desc *used_desc = desc;
-        int r = 0;
+        ssize_t io_bytes = 0;
 
-        memcpy(&req, vm_guest_to_host(v, desc->addr), desc->len);
+        void *hdr = vm_guest_to_host(v, desc->addr);
+        if (!hdr || desc->len < hdr_sz)
+            return;
+        memcpy(&req, hdr, hdr_sz);
         if (req.type == VIRTIO_BLK_T_IN || req.type == VIRTIO_BLK_T_OUT) {
             if (!virtq_check_next(desc))
                 return;
             desc = virtq_get_avail(vq);
             req.data_size = desc->len;
             req.data = vm_guest_to_host(v, desc->addr);
+            if (!req.data)
+                return;
 
-            ssize_t r;
             if (req.type == VIRTIO_BLK_T_IN)
-                r = virtio_blk_read(dev, req.data, req.sector << 9,
-                                    req.data_size);
+                io_bytes = virtio_blk_read(dev, req.data, req.sector << 9,
+                                           req.data_size);
             else
-                r = virtio_blk_write(dev, req.data, req.sector << 9,
-                                     req.data_size);
+                io_bytes = virtio_blk_write(dev, req.data, req.sector << 9,
+                                            req.data_size);
 
-            status = r < 0 ? VIRTIO_BLK_S_IOERR : VIRTIO_BLK_S_OK;
+            status = io_bytes < 0 ? VIRTIO_BLK_S_IOERR : VIRTIO_BLK_S_OK;
         } else {
             status = VIRTIO_BLK_S_UNSUPP;
         }
@@ -128,9 +131,17 @@ static void virtio_blk_complete_request(struct virtq *vq)
             return;
         desc = virtq_get_avail(vq);
         req.status = vm_guest_to_host(v, desc->addr);
+        if (!req.status)
+            return;
         *req.status = status;
+        /* used.len is total bytes the device wrote into device-writable
+         * buffers across the chain: the 1-byte status is always written, plus
+         * io_bytes of data on a successful IN. */
+        size_t written = 1;
+        if (req.type == VIRTIO_BLK_T_IN && io_bytes > 0)
+            written += (size_t) io_bytes;
+        used_desc->len = (uint32_t) written;
         used_desc->flags ^= (1ULL << VRING_PACKED_DESC_F_USED);
-        used_desc->len = r;
         dev->virtio_pci_dev.config.isr_cap.isr_status |= VIRTIO_PCI_ISR_QUEUE;
     }
 }
@@ -141,32 +152,44 @@ static struct virtq_ops ops = {
     .notify_used = virtio_blk_notify_used,
 };
 
-static void virtio_blk_setup(struct virtio_blk_dev *dev,
-                             struct diskimg *diskimg)
+static int virtio_blk_setup(struct virtio_blk_dev *dev, struct diskimg *diskimg)
 {
     vm_t *v = container_of(dev, vm_t, virtio_blk_dev);
+
+    dev->ioeventfd = eventfd(0, EFD_CLOEXEC);
+    dev->stopfd = eventfd(0, EFD_CLOEXEC);
+    dev->irqfd = eventfd(0, EFD_CLOEXEC);
+    if (dev->ioeventfd < 0 || dev->stopfd < 0 || dev->irqfd < 0) {
+        if (dev->ioeventfd >= 0)
+            close(dev->ioeventfd);
+        if (dev->stopfd >= 0)
+            close(dev->stopfd);
+        if (dev->irqfd >= 0)
+            close(dev->irqfd);
+        return throw_err("Failed to create virtio-blk eventfds");
+    }
 
     dev->enable = true;
     /* FIXME: irq_num should be different to other devs */
     dev->irq_num = VIRTIO_BLK_IRQ;
     dev->diskimg = diskimg;
     dev->config.capacity = diskimg->size >> 9;
-    dev->ioeventfd = eventfd(0, EFD_CLOEXEC);
-    dev->irqfd = eventfd(0, EFD_CLOEXEC);
     vm_irqfd_register(v, dev->irqfd, dev->irq_num, 0);
     for (int i = 0; i < VIRTIO_BLK_VIRTQ_NUM; i++)
         virtq_init(&dev->vq[i], dev, &ops);
+    return 0;
 }
 
-void virtio_blk_init_pci(struct virtio_blk_dev *virtio_blk_dev,
-                         struct diskimg *diskimg,
-                         struct pci *pci,
-                         struct bus *io_bus,
-                         struct bus *mmio_bus)
+int virtio_blk_init_pci(struct virtio_blk_dev *virtio_blk_dev,
+                        struct diskimg *diskimg,
+                        struct pci *pci,
+                        struct bus *io_bus,
+                        struct bus *mmio_bus)
 {
     struct virtio_pci_dev *dev = &virtio_blk_dev->virtio_pci_dev;
     /* Initialize the device based on PCI */
-    virtio_blk_setup(virtio_blk_dev, diskimg);
+    if (virtio_blk_setup(virtio_blk_dev, diskimg) < 0)
+        return -1;
     virtio_pci_init(dev, pci, io_bus, mmio_bus);
     virtio_pci_set_dev_cfg(dev, &virtio_blk_dev->config,
                            sizeof(virtio_blk_dev->config));
@@ -175,8 +198,7 @@ void virtio_blk_init_pci(struct virtio_blk_dev *virtio_blk_dev,
     virtio_pci_set_virtq(dev, virtio_blk_dev->vq, VIRTIO_BLK_VIRTQ_NUM);
     virtio_pci_add_feature(dev, 0);
     virtio_pci_enable(dev);
-    pthread_create(&virtio_blk_dev->worker_thread, NULL,
-                   (void *) virtio_blk_thread, (void *) virtio_blk_dev);
+    return 0;
 }
 
 void virtio_blk_init(struct virtio_blk_dev *dev)
@@ -186,12 +208,17 @@ void virtio_blk_init(struct virtio_blk_dev *dev)
 
 void virtio_blk_exit(struct virtio_blk_dev *dev)
 {
+    uint64_t n = 1;
+
     if (!dev->enable)
         return;
-    __atomic_store_n(&thread_stop, true, __ATOMIC_RELAXED);
-    pthread_join(dev->vq_avail_thread, NULL);
+    if (dev->stopfd >= 0 && write(dev->stopfd, &n, sizeof(n)) < 0)
+        throw_err("Failed to wake virtio-blk worker");
+    if (dev->vq_thread_started)
+        pthread_join(dev->vq_avail_thread, NULL);
     diskimg_exit(dev->diskimg);
     virtio_pci_exit(&dev->virtio_pci_dev);
     close(dev->irqfd);
     close(dev->ioeventfd);
+    close(dev->stopfd);
 }

--- a/src/virtio-blk.h
+++ b/src/virtio-blk.h
@@ -28,17 +28,18 @@ struct virtio_blk_dev {
     struct virtq vq[VIRTIO_BLK_VIRTQ_NUM];
     int irqfd;
     int ioeventfd;
+    int stopfd;
     int irq_num;
     pthread_t vq_avail_thread;
-    pthread_t worker_thread;
     struct diskimg *diskimg;
+    bool vq_thread_started;
     bool enable;
 };
 
 void virtio_blk_init(struct virtio_blk_dev *virtio_blk_dev);
 void virtio_blk_exit(struct virtio_blk_dev *dev);
-void virtio_blk_init_pci(struct virtio_blk_dev *dev,
-                         struct diskimg *diskimg,
-                         struct pci *pci,
-                         struct bus *io_bus,
-                         struct bus *mmio_bus);
+int virtio_blk_init_pci(struct virtio_blk_dev *dev,
+                        struct diskimg *diskimg,
+                        struct pci *pci,
+                        struct bus *io_bus,
+                        struct bus *mmio_bus);

--- a/src/virtio-net.c
+++ b/src/virtio-net.c
@@ -24,30 +24,40 @@
 #define VIRTQ_TX 1
 #define NOTIFY_OFFSET 2
 
-static volatile bool thread_stop = false;
-
-static int virtio_net_virtq_available_rx(struct virtio_net_dev *dev,
-                                         int timeout)
+static bool virtio_net_stop_requested(struct virtio_net_dev *dev)
 {
     struct pollfd pollfd = (struct pollfd) {
-        .fd = dev->tapfd,
+        .fd = dev->stopfd,
         .events = POLLIN,
     };
-    return (poll(&pollfd, 1, timeout) > 0) && (pollfd.revents & POLLIN);
+    return poll(&pollfd, 1, 0) > 0 && (pollfd.revents & POLLIN);
 }
 
-static int virtio_net_virtq_available_tx(struct virtio_net_dev *dev,
-                                         int timeout)
+static bool virtio_net_poll_rx(struct virtio_net_dev *dev)
+{
+    struct pollfd pollfds[] = {
+        [0] = {.fd = dev->tapfd, .events = POLLIN},
+        [1] = {.fd = dev->stopfd, .events = POLLIN},
+    };
+
+    int ret = poll(pollfds, 2, -1);
+
+    return ret > 0 && (pollfds[0].revents & POLLIN) &&
+           !(pollfds[1].revents & POLLIN);
+}
+
+static bool virtio_net_poll_tx(struct virtio_net_dev *dev)
 {
     struct pollfd pollfds[] = {
         [0] = {.fd = dev->tx_ioeventfd, .events = POLLIN},
         [1] = {.fd = dev->tapfd, .events = POLLOUT},
+        [2] = {.fd = dev->stopfd, .events = POLLIN},
     };
 
-    int ret = poll(pollfds, 2, timeout);
+    int ret = poll(pollfds, 3, -1);
 
     return ret > 0 && (pollfds[0].revents & POLLIN) &&
-           (pollfds[1].revents & POLLOUT);
+           (pollfds[1].revents & POLLOUT) && !(pollfds[2].revents & POLLIN);
 }
 
 static void *virtio_net_vq_avail_handler_rx(void *arg)
@@ -55,9 +65,9 @@ static void *virtio_net_vq_avail_handler_rx(void *arg)
     struct virtq *vq = (struct virtq *) arg;
     struct virtio_net_dev *dev = (struct virtio_net_dev *) vq->dev;
 
-    while (!__atomic_load_n(&thread_stop, __ATOMIC_RELAXED)) {
+    while (!virtio_net_stop_requested(dev)) {
         vq->guest_event->flags = VRING_PACKED_EVENT_FLAG_ENABLE;
-        if (virtio_net_virtq_available_rx(dev, -1))
+        if (virtio_net_poll_rx(dev))
             virtq_handle_avail(vq);
     }
     return NULL;
@@ -68,9 +78,9 @@ static void *virtio_net_vq_avail_handler_tx(void *arg)
     struct virtq *vq = (struct virtq *) arg;
     struct virtio_net_dev *dev = (struct virtio_net_dev *) vq->dev;
 
-    while (!__atomic_load_n(&thread_stop, __ATOMIC_RELAXED)) {
+    while (!virtio_net_stop_requested(dev)) {
         vq->guest_event->flags = VRING_PACKED_EVENT_FLAG_ENABLE;
-        if (virtio_net_virtq_available_tx(dev, -1))
+        if (virtio_net_poll_tx(dev))
             virtq_handle_avail(vq);
     }
     return NULL;
@@ -92,8 +102,9 @@ static void virtio_net_enable_vq_rx(struct virtq *vq)
         v, vq->info.driver_addr);
     uint64_t addr = virtio_pci_get_notify_addr(&dev->virtio_pci_dev, vq);
     vm_ioeventfd_register(v, dev->rx_ioeventfd, addr, NOTIFY_OFFSET, 0);
-    pthread_create(&dev->rx_thread, NULL, virtio_net_vq_avail_handler_rx,
-                   (void *) vq);
+    if (pthread_create(&dev->rx_thread, NULL, virtio_net_vq_avail_handler_rx,
+                       (void *) vq) == 0)
+        dev->rx_thread_started = true;
 }
 
 static void virtio_net_enable_vq_tx(struct virtq *vq)
@@ -113,8 +124,9 @@ static void virtio_net_enable_vq_tx(struct virtq *vq)
 
     uint64_t addr = virtio_pci_get_notify_addr(&dev->virtio_pci_dev, vq);
     vm_ioeventfd_register(v, dev->tx_ioeventfd, addr, NOTIFY_OFFSET, 0);
-    pthread_create(&dev->tx_thread, NULL, virtio_net_vq_avail_handler_tx,
-                   (void *) vq);
+    if (pthread_create(&dev->tx_thread, NULL, virtio_net_vq_avail_handler_tx,
+                       (void *) vq) == 0)
+        dev->tx_thread_started = true;
 }
 
 static void virtio_net_notify_used_rx(struct virtq *vq)
@@ -234,30 +246,46 @@ bool virtio_net_init(struct virtio_net_dev *virtio_net_dev)
     return true;
 }
 
-static void virtio_net_setup(struct virtio_net_dev *dev)
+static int virtio_net_setup(struct virtio_net_dev *dev)
 {
     vm_t *v = container_of(dev, vm_t, virtio_net_dev);
 
-    dev->enable = true;
-    dev->irq_num = VIRTIO_NET_IRQ;
     dev->rx_ioeventfd = eventfd(0, EFD_CLOEXEC);
     dev->tx_ioeventfd = eventfd(0, EFD_CLOEXEC);
+    dev->stopfd = eventfd(0, EFD_CLOEXEC);
     dev->irqfd = eventfd(0, EFD_CLOEXEC);
+    if (dev->rx_ioeventfd < 0 || dev->tx_ioeventfd < 0 || dev->stopfd < 0 ||
+        dev->irqfd < 0) {
+        if (dev->rx_ioeventfd >= 0)
+            close(dev->rx_ioeventfd);
+        if (dev->tx_ioeventfd >= 0)
+            close(dev->tx_ioeventfd);
+        if (dev->stopfd >= 0)
+            close(dev->stopfd);
+        if (dev->irqfd >= 0)
+            close(dev->irqfd);
+        return throw_err("Failed to create virtio-net eventfds");
+    }
+
+    dev->enable = true;
+    dev->irq_num = VIRTIO_NET_IRQ;
     vm_irqfd_register(v, dev->irqfd, dev->irq_num, 0);
     for (int i = 0; i < VIRTIO_NET_VIRTQ_NUM; i++) {
         struct virtq_ops *ops = &virtio_net_ops[i];
         dev->vq[i].info.notify_off = i;
         virtq_init(&dev->vq[i], dev, ops);
     }
+    return 0;
 }
 
-void virtio_net_init_pci(struct virtio_net_dev *virtio_net_dev,
-                         struct pci *pci,
-                         struct bus *io_bus,
-                         struct bus *mmio_bus)
+int virtio_net_init_pci(struct virtio_net_dev *virtio_net_dev,
+                        struct pci *pci,
+                        struct bus *io_bus,
+                        struct bus *mmio_bus)
 {
     struct virtio_pci_dev *dev = &virtio_net_dev->virtio_pci_dev;
-    virtio_net_setup(virtio_net_dev);
+    if (virtio_net_setup(virtio_net_dev) < 0)
+        return -1;
     virtio_pci_init(dev, pci, io_bus, mmio_bus);
     virtio_pci_set_dev_cfg(dev, &virtio_net_dev->config,
                            sizeof(virtio_net_dev->config));
@@ -268,18 +296,25 @@ void virtio_net_init_pci(struct virtio_net_dev *virtio_net_dev,
 
     virtio_pci_add_feature(dev, VIRTIO_NET_F_MQ);
     virtio_pci_enable(dev);
+    return 0;
 }
 
 void virtio_net_exit(struct virtio_net_dev *dev)
 {
+    uint64_t n = 1;
+
     if (!dev->enable)
         return;
-    __atomic_store_n(&thread_stop, true, __ATOMIC_RELAXED);
-    pthread_join(dev->rx_thread, NULL);
-    pthread_join(dev->tx_thread, NULL);
+    if (dev->stopfd >= 0 && write(dev->stopfd, &n, sizeof(n)) < 0)
+        throw_err("Failed to wake virtio-net workers");
+    if (dev->rx_thread_started)
+        pthread_join(dev->rx_thread, NULL);
+    if (dev->tx_thread_started)
+        pthread_join(dev->tx_thread, NULL);
     virtio_pci_exit(&dev->virtio_pci_dev);
     close(dev->irqfd);
     close(dev->rx_ioeventfd);
     close(dev->tx_ioeventfd);
+    close(dev->stopfd);
     close(dev->tapfd);
 }

--- a/src/virtio-net.h
+++ b/src/virtio-net.h
@@ -16,15 +16,18 @@ struct virtio_net_dev {
     int irqfd;
     int rx_ioeventfd;
     int tx_ioeventfd;
+    int stopfd;
     int irq_num;
     pthread_t rx_thread;
     pthread_t tx_thread;
+    bool rx_thread_started;
+    bool tx_thread_started;
     bool enable;
 };
 
 bool virtio_net_init(struct virtio_net_dev *virtio_net_dev);
 void virtio_net_exit(struct virtio_net_dev *virtio_net_dev);
-void virtio_net_init_pci(struct virtio_net_dev *virtio_net_dev,
-                         struct pci *pci,
-                         struct bus *io_bus,
-                         struct bus *mmio_bus);
+int virtio_net_init_pci(struct virtio_net_dev *virtio_net_dev,
+                        struct pci *pci,
+                        struct bus *io_bus,
+                        struct bus *mmio_bus);

--- a/src/virtio-pci.c
+++ b/src/virtio-pci.c
@@ -280,7 +280,8 @@ void virtio_pci_enable(struct virtio_pci_dev *dev)
     pci_dev_register(&dev->pci_dev);
 }
 
-void virtio_pci_exit()
+void virtio_pci_exit(struct virtio_pci_dev *dev)
 {
+    (void) dev;
     /* TODO: exit of the virtio pci device */
 }

--- a/src/virtio-pci.h
+++ b/src/virtio-pci.h
@@ -55,4 +55,4 @@ void virtio_pci_init(struct virtio_pci_dev *dev,
                      struct pci *pci,
                      struct bus *io_bus,
                      struct bus *mmio_bus);
-void virtio_pci_exit();
+void virtio_pci_exit(struct virtio_pci_dev *dev);

--- a/src/vm.c
+++ b/src/vm.c
@@ -26,7 +26,7 @@ int vm_init(vm_t *v)
 
     v->mem = mmap(NULL, RAM_SIZE, PROT_READ | PROT_WRITE,
                   MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-    if (!v->mem)
+    if (v->mem == MAP_FAILED)
         return throw_err("Failed to mmap vm memory");
 
     struct kvm_userspace_memory_region region = {
@@ -58,13 +58,18 @@ int vm_load_image(vm_t *v, const char *image_path)
 {
     int fd = open(image_path, O_RDONLY);
     if (fd < 0)
-        return 1;
+        return throw_err("Failed to open %s", image_path);
 
     struct stat st;
-    fstat(fd, &st);
+    if (fstat(fd, &st) < 0) {
+        close(fd);
+        return throw_err("Failed to stat %s", image_path);
+    }
     size_t datasz = st.st_size;
     void *data = mmap(0, datasz, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
     close(fd);
+    if (data == MAP_FAILED)
+        return throw_err("Failed to mmap %s", image_path);
 
     int ret = vm_arch_load_image(v, data, datasz);
     munmap(data, datasz);
@@ -75,13 +80,18 @@ int vm_load_initrd(vm_t *v, const char *initrd_path)
 {
     int fd = open(initrd_path, O_RDONLY);
     if (fd < 0)
-        return 1;
+        return throw_err("Failed to open %s", initrd_path);
 
     struct stat st;
-    fstat(fd, &st);
+    if (fstat(fd, &st) < 0) {
+        close(fd);
+        return throw_err("Failed to stat %s", initrd_path);
+    }
     size_t datasz = st.st_size;
     void *data = mmap(0, datasz, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
     close(fd);
+    if (data == MAP_FAILED)
+        return throw_err("Failed to mmap %s", initrd_path);
 
     int ret = vm_arch_load_initrd(v, data, datasz);
     munmap(data, datasz);
@@ -92,17 +102,16 @@ int vm_load_diskimg(vm_t *v, const char *diskimg_file)
 {
     if (diskimg_init(&v->diskimg, diskimg_file) < 0)
         return -1;
-    virtio_blk_init_pci(&v->virtio_blk_dev, &v->diskimg, &v->pci, &v->io_bus,
-                        &v->mmio_bus);
-    return 0;
+    return virtio_blk_init_pci(&v->virtio_blk_dev, &v->diskimg, &v->pci,
+                               &v->io_bus, &v->mmio_bus);
 }
 
 int vm_enable_net(vm_t *v)
 {
     if (!virtio_net_init(&v->virtio_net_dev))
         return -1;
-    virtio_net_init_pci(&v->virtio_net_dev, &v->pci, &v->io_bus, &v->mmio_bus);
-    return 0;
+    return virtio_net_init_pci(&v->virtio_net_dev, &v->pci, &v->io_bus,
+                               &v->mmio_bus);
 }
 
 void vm_handle_io(vm_t *v, struct kvm_run *run)
@@ -126,8 +135,12 @@ void vm_handle_mmio(vm_t *v, struct kvm_run *run)
 int vm_run(vm_t *v)
 {
     int run_size = ioctl(v->kvm_fd, KVM_GET_VCPU_MMAP_SIZE, 0);
+    if (run_size < 0)
+        return throw_err("Failed to get VCPU mmap size");
     struct kvm_run *run =
         mmap(0, run_size, PROT_READ | PROT_WRITE, MAP_SHARED, v->vcpu_fd, 0);
+    if (run == MAP_FAILED)
+        return throw_err("Failed to mmap kvm_run");
 
     while (1) {
         int err = ioctl(v->vcpu_fd, KVM_RUN, 0);
@@ -158,7 +171,7 @@ int vm_run(vm_t *v)
 
 void *vm_guest_to_host(vm_t *v, uint64_t guest)
 {
-    if (guest < RAM_BASE)
+    if (guest < RAM_BASE || guest >= RAM_BASE + RAM_SIZE)
         return NULL;
     return (void *) ((uintptr_t) v->mem + guest - RAM_BASE);
 }
@@ -196,6 +209,7 @@ void vm_exit(vm_t *v)
 {
     serial_exit(&v->serial);
     virtio_blk_exit(&v->virtio_blk_dev);
+    virtio_net_exit(&v->virtio_net_dev);
     close(v->kvm_fd);
     close(v->vm_fd);
     close(v->vcpu_fd);


### PR DESCRIPTION
Correctness / security:
- vm: vm_guest_to_host now rejects guest >= RAM_BASE + RAM_SIZE so a guest descriptor cannot translate into host memory beyond the mmap'd region.
- vm: mmap success checks corrected (mmap returns MAP_FAILED, not NULL); fstat returns and KVM_GET_VCPU_MMAP_SIZE result are checked.
- virtio-blk: bound the request-header memcpy to the wire-format prefix so a guest-controlled desc->len cannot clobber the trailing host pointers in struct virtio_blk_req. Reject desc->len < hdr_sz so the request fields are not interpreted from uninitialized stack memory.
- virtio-blk: drop the shadowed \`r\` that always wrote 0 into used_desc->len. Report total bytes written into device-writable buffers across the chain (status byte + IN data on success).
- arch/x86: E820 low-RAM region size was off by one.
- serial: UART_LSR read returns the atomic snapshot, not a follow-up non-atomic load.
- main: --help exits 0.
- virtio-pci: virtio_pci_exit gets a real prototype.

Worker-thread shutdown:
- virtio-blk: remove the SIGUSR1 worker thread. Default action of SIGUSR1 with no handler is to terminate the process; the avail handler on its own is sufficient.
- virtio-blk / virtio-net / serial: replace the global \`thread_stop\` flag with a per-device stopfd (eventfd). Workers poll their primary fds together with stopfd; *_exit writes 1 to stopfd to wake them. Each pthread_join is gated on a *_thread_started bool so unenabled queues do not join a zero pthread_t.
- vm_exit: now also tears down virtio-net (was leaking rx/tx threads, tapfd, eventfds).

Validated on Ubuntu 24.04 / x86_64: Linux 6.1 boots with initramfs, ext4 disk mounts, file read/write through virtio-blk works.