### PR TITLE
CI: Do prebuilt images and drift detection

### DIFF
--- a/.ci/autorun.sh
+++ b/.ci/autorun.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Smoke-test that kvm-host launches, loads the guest kernel, the guest
+# starts producing boot output through the emulated serial, and the
+# Ctrl-A x exit path in src/serial.c shuts the host down cleanly.
+#
+# We deliberately do NOT assert a full boot to a busybox shell here.
+# GH-hosted ubuntu-24.04 runners are themselves KVM guests, and under
+# nested KVM the guest hangs partway through APIC bring-up
+# ("Not enabling interrupt remapping due to skipped IO-APIC setup")
+# even though the same kernel + kvm-host boots through to userspace
+# on a real Ubuntu 24.04 host. Until the nested-KVM environment is
+# replaced with a self-hosted runner that has bare-metal /dev/kvm, a
+# smoke test is the strongest assertion this CI can carry without
+# false-failing on environment limitations.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/common.sh"
+
+cleanup
+
+# Run expect directly (not through ASSERT) so the case statement below
+# actually sees the cause-specific exit codes; ASSERT exits the script
+# on failure, which would make the mapping dead code.
+#
+# Successful path: spawn make check -> wait for the kernel banner so
+# we know kvm-host loaded the image and entered KVM_RUN -> send Ctrl-A x
+# (the escape sequence src/serial.c recognizes) -> wait for kvm-host
+# to exit. Each branch carries a distinct exit code so the case
+# statement below names the failure mode.
+set +e
+expect <<EXPECT
+set timeout ${TIMEOUT}
+log_user 1
+spawn make check
+
+expect {
+    "Kernel panic - not syncing" { exit 1 }
+    "Linux version "             { send "\x01x" }
+    timeout                      { exit 2 }
+}
+
+expect eof
+EXPECT
+ret="$?"
+set -e
+
+case "$ret" in
+    0) print_ok   "OK!" ;;
+    1) print_fail "Guest hit a kernel panic" ;;
+    2) print_fail "kvm-host did not produce kernel boot output" ;;
+    *) print_fail "Smoke test exited with status $ret" ;;
+esac
+
+exit "$ret"

--- a/.ci/check-format.sh
+++ b/.ci/check-format.sh
@@ -1,17 +1,16 @@
 #!/usr/bin/env bash
 
-set -e -u -o pipefail
+set -euo pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 
-set -x
+# clang-format-20 -n --Werror exits non-zero on the first violation, which
+# is exactly what we want from CI. Drops the temp-file + diff loop the old
+# script used (which also wrapped exit codes >255).
+sources=()
+while IFS= read -r f; do
+    sources+=("$f")
+done < <(git ls-files '*.c' '*.cxx' '*.cpp' '*.h' '*.hpp' \
+         | grep -v '^src/dtc/')
 
-while IFS= read -r -d '' file; do
-    clang-format-20 "$file" > expected-format
-    diff -u -p --label="$file" --label="expected coding style" "$file" expected-format
-done < <(git ls-files -z '*.c' '*.cxx' '*.cpp' '*.h' '*.hpp')
-
-count=$(git ls-files -z '*.c' '*.cxx' '*.cpp' '*.h' '*.hpp' \
-    | xargs -0 clang-format-20 --output-replacements-xml \
-    | grep -c "</replacement>" || true)
-exit "$count"
+clang-format-20 -n --Werror "${sources[@]}"

--- a/.ci/common.sh
+++ b/.ci/common.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Shared helpers for kvm-host CI scripts.
+
+set -euo pipefail
+
+# Kill stray kvm-host processes so a failed test cannot wedge a CI runner
+# (or a developer's terminal). Run with sudo too because make check spawns
+# the binary as root.
+cleanup() {
+    sleep 1
+    pkill -9 -f '(^|/)kvm-host( |$)' 2>/dev/null || true
+    sudo -n pkill -9 -f '(^|/)kvm-host( |$)' 2>/dev/null || true
+}
+trap cleanup EXIT INT TERM
+
+# Run a command and propagate its exit code with a clear message. Mirrors
+# the ASSERT pattern used in externals/semu/.ci/common.sh so the autorun
+# script reads the same way as upstream.
+ASSERT() {
+    local rc
+    set +e
+    "$@"
+    rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+        printf 'Assert failed: %s\n' "$*" >&2
+        exit "$rc"
+    fi
+}
+
+# Smoke-test budget. autorun.sh only waits for the kernel banner before
+# sending Ctrl-A x; 60 s is plenty even on slow nested-KVM runners.
+TIMEOUT="${KVM_HOST_TEST_TIMEOUT:-60}"
+export TIMEOUT
+
+COLOR_GREEN='\e[32;01m'
+COLOR_RED='\e[31;01m'
+COLOR_RESET='\e[0m'
+
+print_ok()   { printf '\n[ %b%s%b ]\n'   "$COLOR_GREEN" "$1" "$COLOR_RESET"; }
+print_fail() { printf '\n[ %b%s%b ]\n' "$COLOR_RED"   "$1" "$COLOR_RESET" >&2; }

--- a/.ci/inputs-hash.sh
+++ b/.ci/inputs-hash.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Compute the SHA1 of the inputs that determine prebuilt content. The
+# publish step and the PR drift check both call this -- their outputs
+# MUST agree, so factor the hashing here rather than copy-paste it.
+#
+# Inputs (deterministic order):
+#   configs/linux-x86.config
+#   configs/busybox.config
+#   target/rc-startup
+#   mk/external.mk           [auto-managed pin lines stripped]
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+if command -v sha1sum >/dev/null 2>&1; then
+    SHA1=(sha1sum)
+elif command -v shasum >/dev/null 2>&1; then
+    SHA1=(shasum -a 1)
+else
+    echo "[!] Need sha1sum (Linux) or shasum (macOS) on PATH" >&2
+    exit 1
+fi
+
+{
+    cat configs/linux-x86.config \
+        configs/busybox.config \
+        target/rc-startup
+    # Strip auto-managed pin lines (anchored to the assignment operator
+    # so a comment containing those tokens cannot accidentally match) so
+    # external.mk's own hash does not bake in the values it stores.
+    grep -v -E '^(KERNEL|INITRD|PREBUILT)_(DATA|INPUTS)_SHA1[[:space:]]*=' \
+        mk/external.mk
+} | tr -d '\r' | "${SHA1[@]}" | awk '{print $1}'

--- a/.ci/publish-prebuilt.sh
+++ b/.ci/publish-prebuilt.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Compress build/bzImage and build/rootfs.cpio, write a sha1 manifest, hash
+# the input files that define what the prebuilt contains, and emit all
+# three sums in KEY=VAL form on stdout for splicing into release notes or
+# $GITHUB_OUTPUT.
+#
+# Inputs (in cwd):
+#   build/bzImage
+#   build/rootfs.cpio
+#   plus the source inputs listed in INPUTS below (configs + target +
+#   mk/external.mk minus its auto-managed pin lines)
+#
+# Outputs (in cwd):
+#   bzImage.bz2
+#   rootfs.cpio.bz2
+#   prebuilt.sha1   -- two-line manifest in standard `sha1sum` format
+#
+# Stdout (machine-readable, one assignment per line):
+#   kernel_sha1=<sha1 of bzImage.bz2>
+#   initrd_sha1=<sha1 of rootfs.cpio.bz2>
+#   inputs_sha1=<sha1 of the concatenated input files>
+
+set -euo pipefail
+
+# Pick a SHA1 tool. macOS dropped sha1sum from base; shasum -a 1 is the
+# portable fallback. CI runs on Linux so sha1sum is the hot path.
+if command -v sha1sum >/dev/null 2>&1; then
+    SHA1=(sha1sum)
+elif command -v shasum >/dev/null 2>&1; then
+    SHA1=(shasum -a 1)
+else
+    echo "[!] Need sha1sum (Linux) or shasum (macOS) on PATH" >&2
+    exit 1
+fi
+
+# Inputs that determine prebuilt content. Keep in sync with the `paths:`
+# filter in .github/workflows/prebuilt.yml and the drift check in main.yml.
+# mk/external.mk is filtered to drop the auto-managed SHA1 lines so its
+# own hash does not depend on the pin values it stores.
+INPUTS=(
+    configs/linux-x86.config
+    configs/busybox.config
+    target/rc-startup
+)
+
+for f in build/bzImage build/rootfs.cpio "${INPUTS[@]}" mk/external.mk; do
+    if [ ! -f "$f" ]; then
+        echo "[!] Missing $f -- run scripts/build-image.sh --all first" >&2
+        exit 1
+    fi
+done
+
+bzip2 -k -f build/bzImage
+bzip2 -k -f build/rootfs.cpio
+mv -f build/bzImage.bz2     ./bzImage.bz2
+mv -f build/rootfs.cpio.bz2 ./rootfs.cpio.bz2
+
+KERNEL_SHA1=$("${SHA1[@]}" bzImage.bz2     | awk '{print $1}')
+INITRD_SHA1=$("${SHA1[@]}" rootfs.cpio.bz2 | awk '{print $1}')
+
+# Concatenate inputs in deterministic order and hash the stream. The drift
+# check in main.yml calls the same helper, so both values must agree.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INPUTS_SHA1=$("${SCRIPT_DIR}/inputs-hash.sh")
+
+{
+    echo "$KERNEL_SHA1  bzImage.bz2"
+    echo "$INITRD_SHA1  rootfs.cpio.bz2"
+} > prebuilt.sha1
+
+# Echo manifest + inputs hash to stderr for visibility in CI logs without
+# polluting the parseable stdout block below.
+{
+    cat prebuilt.sha1
+    echo "inputs_sha1: $INPUTS_SHA1"
+} >&2
+
+echo "kernel_sha1=$KERNEL_SHA1"
+echo "initrd_sha1=$INITRD_SHA1"
+echo "inputs_sha1=$INPUTS_SHA1"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,13 @@ name: CI
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   detect-code-related-file-changes:
     runs-on: ubuntu-24.04
@@ -19,6 +26,9 @@ jobs:
               mk/**
               src/**
               target/**
+              configs/**
+              scripts/**
+              .github/workflows/**
               .clang-format
               Makefile
       - name: Set has_code_related_changes
@@ -30,33 +40,170 @@ jobs:
             echo "has_code_related_changes=false" >> $GITHUB_OUTPUT
           fi
 
+  # PR-only: rebuild bzImage/rootfs.cpio from source when local kernel
+  # and rootfs inputs have drifted from the prebuilt's recorded inputs.
+  # Without this, a PR that touches configs, target/, or mk/external.mk
+  # would silently exercise the stale prebuilt instead of the
+  # contributor's actual change.
+  #
+  # Artifacts are published as a workflow artifact (reliable cross-job
+  # handoff) and consumed by the test job below. They are NOT published
+  # to the prebuilt GitHub release; that path is owned by
+  # .github/workflows/prebuilt.yml on master push.
+  pr-prebuilt-build:
+    runs-on: ubuntu-24.04
+    outputs:
+      should_build: ${{ steps.detect.outputs.should_build }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: detect input drift
+        id: detect
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Strip CR + trailing whitespace so a value pasted from a Mac
+          # editor or with stray spaces doesn't trigger perpetual drift.
+          expected=$(sed -n 's/^PREBUILT_INPUTS_SHA1[[:space:]]*=[[:space:]]*//p' mk/external.mk \
+              | head -1 | tr -d '\r' | sed 's/[[:space:]]*$//')
+          live=$(.ci/inputs-hash.sh)
+          if [ -z "$expected" ]; then
+            echo "Prebuilt not yet pinned in mk/external.mk; rebuilding from source"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          elif [ "$live" = "$expected" ]; then
+            echo "PR inputs match the prebuilt ($live); skipping rebuild"
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "PR inputs drifted ($live != $expected); will rebuild from source"
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: install build dependencies
+        if: steps.detect.outputs.should_build == 'true'
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            build-essential bc bison flex cpio libssl-dev libelf-dev \
+            wget curl python3
+        timeout-minutes: 5
+      - name: build kernel and rootfs from source
+        if: steps.detect.outputs.should_build == 'true'
+        run: ./scripts/build-image.sh --all
+        timeout-minutes: 60
+      # Pre-create stamp files matching the SHA1 pins still in mk/external.mk
+      # so that when host-x64's `make` evaluates the prebuilt branch, it
+      # sees both image and stamp present and skips the redownload that
+      # would otherwise clobber our freshly-built artifacts with the OLD
+      # release content. Bootstrap PRs (no pin yet) skip this step, which
+      # is correct -- the source-build branch has no stamp dependency.
+      - name: stage prebuilt stamps to suppress redownload
+        if: steps.detect.outputs.should_build == 'true'
+        shell: bash
+        run: |
+          extract() {
+            sed -n "s/^$1[[:space:]]*=[[:space:]]*//p" mk/external.mk \
+              | head -1 | tr -d '\r' | sed 's/[[:space:]]*$//'
+          }
+          kernel_pin=$(extract KERNEL_DATA_SHA1)
+          initrd_pin=$(extract INITRD_DATA_SHA1)
+          mkdir -p build
+          [ -n "$kernel_pin" ] && touch "build/.prebuilt-kernel-$kernel_pin.stamp"
+          [ -n "$initrd_pin" ] && touch "build/.prebuilt-initrd-$initrd_pin.stamp"
+          # Touch images last so make sees them no older than the stamps.
+          touch build/bzImage build/rootfs.cpio
+          ls -la build/
+      - name: upload PR-built artifacts
+        if: steps.detect.outputs.should_build == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: prebuilt-pr
+          path: |
+            build/bzImage
+            build/rootfs.cpio
+            build/.prebuilt-*.stamp
+          retention-days: 1
+          if-no-files-found: error
+
   host-x64:
-    needs: [detect-code-related-file-changes]
+    needs: [detect-code-related-file-changes, pr-prebuilt-build]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
-    - name: default build
-      run: make
+      - uses: actions/checkout@v6
+      # Drift PR: pull the freshly-built bzImage/rootfs.cpio from
+      # pr-prebuilt-build via workflow artifact. No `path:` because
+      # upload-artifact already records each file with its `build/`
+      # prefix; specifying `path: build/` here would produce build/build/.
+      - name: download PR-built kernel/rootfs
+        if: needs.pr-prebuilt-build.outputs.should_build == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: prebuilt-pr
+      # Non-drift PR or master push: cache the release-downloaded (or
+      # source-built, on the bootstrap pass before the first prerelease)
+      # artifacts across runs. mk/external.mk participates in the key so
+      # checksum or input-pin bumps invalidate the old pair.
+      - name: cache external downloads
+        if: needs.pr-prebuilt-build.outputs.should_build != 'true'
+        uses: actions/cache@v5
+        with:
+          # Stamps must travel with the images: cache hit without the
+          # matching stamp would trip the prebuilt branch's freshness
+          # check and trigger an unnecessary redownload.
+          path: |
+            build/bzImage
+            build/rootfs.cpio
+            build/.prebuilt-kernel-*.stamp
+            build/.prebuilt-initrd-*.stamp
+          key: external-${{ hashFiles('mk/external.mk', 'configs/linux-x86.config', 'configs/busybox.config', 'target/**') }}
+      - name: install build and test dependencies
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            build-essential bc bison flex cpio libssl-dev libelf-dev \
+            wget curl python3 e2fsprogs expect
+        timeout-minutes: 5
+      - name: ensure /dev/kvm available
+        run: |
+          if [ ! -e /dev/kvm ]; then
+            echo "::error::/dev/kvm missing on this runner"
+            exit 1
+          fi
+          ls -l /dev/kvm
+          sudo chmod 666 /dev/kvm || true
+      - name: default build
+        run: make
+        timeout-minutes: 5
+      # Materialize bzImage, rootfs.cpio, and ext4.img up front so the boot
+      # test's expect timeout window only has to cover the actual guest
+      # boot (~30 s) -- not a 15-minute fresh kernel source build that
+      # happens on the bootstrap pass before any prebuilt or cache exists.
+      - name: build kernel and rootfs images
+        run: make build/bzImage build/rootfs.cpio build/ext4.img
+        timeout-minutes: 30
+      - name: boot test
+        run: .ci/autorun.sh
+        timeout-minutes: 5
 
   coding-style:
     needs: [detect-code-related-file-changes]
     if: needs.detect-code-related-file-changes.outputs.has_code_related_changes == 'true'
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v6
-    - name: Install clang-format-20
-      run: |
-            sudo install -m 0755 -d /etc/apt/keyrings
-            wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
-                | sudo gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
-            echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" \
-                | sudo tee /etc/apt/sources.list.d/llvm.list
-            sudo apt-get update
-            sudo apt-get install -q -y clang-format-20
-      shell: bash
-    - name: coding convention
-      run: |
-            .ci/check-newline.sh
-            .ci/check-format.sh
-      shell: bash
+      - uses: actions/checkout@v6
+      - name: Install clang-format-20
+        run: |
+          sudo install -m 0755 -d /etc/apt/keyrings
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+              | sudo gpg --dearmor -o /etc/apt/keyrings/llvm.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/llvm.gpg] http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" \
+              | sudo tee /etc/apt/sources.list.d/llvm.list
+          sudo apt-get update
+          sudo apt-get install -q -y clang-format-20
+        shell: bash
+      - name: coding convention
+        run: |
+          .ci/check-newline.sh
+          .ci/check-format.sh
+        shell: bash

--- a/.github/workflows/prebuilt.yml
+++ b/.github/workflows/prebuilt.yml
@@ -1,0 +1,100 @@
+name: Publish prebuilt images
+
+# Builds the Linux kernel and BusyBox rootfs that the rest of CI and
+# `make` on a fresh checkout consume, then publishes them as assets on a
+# fixed-tag GitHub prerelease so the download URL stays stable across
+# rebuilds, keeping large binary artifacts out of the source tree.
+#
+# Triggers automatically on master pushes that touch any input listed in
+# the paths filter below, and can be invoked manually via
+# workflow_dispatch. The resulting SHA1 sums must be reflected in
+# mk/external.mk (KERNEL_DATA_SHA1, INITRD_DATA_SHA1, PREBUILT_INPUTS_SHA1)
+# in a follow-up commit -- the workflow run notes print the exact lines
+# to paste.
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths:
+      - 'configs/linux-x86.config'
+      - 'configs/busybox.config'
+      - 'target/**'
+      - 'mk/external.mk'
+      - 'scripts/build-image.sh'
+      - '.ci/publish-prebuilt.sh'
+      - '.ci/inputs-hash.sh'
+      - '.github/workflows/prebuilt.yml'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: prebuilt
+  cancel-in-progress: false
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: install build dependencies
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            build-essential bc bison flex cpio libssl-dev libelf-dev \
+            wget curl python3
+        timeout-minutes: 5
+
+      - name: build kernel and rootfs from source
+        run: ./scripts/build-image.sh --all
+        timeout-minutes: 60
+
+      - name: compress and checksum artifacts
+        id: checksum
+        # Shell logic lives in .ci/publish-prebuilt.sh so it can be
+        # exercised locally and stays out of the YAML.
+        run: |
+          set -euo pipefail
+          .ci/publish-prebuilt.sh >> "$GITHUB_OUTPUT"
+          ls -la bzImage.bz2 rootfs.cpio.bz2 prebuilt.sha1
+
+      - name: update prebuilt prerelease
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: prebuilt
+          name: Prebuilt images (rolling)
+          prerelease: true
+          # Replace existing assets at the prebuilt tag rather than
+          # appending duplicates with new names.
+          fail_on_unmatched_files: true
+          files: |
+            bzImage.bz2
+            rootfs.cpio.bz2
+            prebuilt.sha1
+          body: |
+            Rolling prerelease of the Linux kernel and BusyBox rootfs
+            consumed by `mk/external.mk`. Re-published whenever any
+            input that defines the kernel/rootfs content changes.
+
+            ## Update `mk/external.mk`
+
+            Paste these three lines into `mk/external.mk` to pin a fresh
+            `make` checkout to this build. `PREBUILT_INPUTS_SHA1` is what
+            local checkouts compare against to detect when their configs
+            have drifted from the prebuilt.
+
+            ```make
+            KERNEL_DATA_SHA1     = ${{ steps.checksum.outputs.kernel_sha1 }}
+            INITRD_DATA_SHA1     = ${{ steps.checksum.outputs.initrd_sha1 }}
+            PREBUILT_INPUTS_SHA1 = ${{ steps.checksum.outputs.inputs_sha1 }}
+            ```
+
+            ## Raw checksums
+
+            ```
+            ${{ steps.checksum.outputs.kernel_sha1 }}  bzImage.bz2
+            ${{ steps.checksum.outputs.initrd_sha1 }}  rootfs.cpio.bz2
+            ${{ steps.checksum.outputs.inputs_sha1 }}  inputs (configs + target/rc-startup + stripped mk/external.mk)
+            ```

--- a/mk/common.mk
+++ b/mk/common.mk
@@ -1,9 +1,19 @@
+# Delete partially-written targets when a recipe fails. Without this, a
+# half-decompressed bzImage or interrupted curl leaves a wrong-sized file
+# that make would happily skip on the next invocation.
+.DELETE_ON_ERROR:
+
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Darwin)
     PRINTF = printf
 else
     PRINTF = env printf
 endif
+
+# SHA1 tool: prefer GNU coreutils on Linux, fall back to Perl-based shasum
+# on macOS or minimal Linux images that lack sha1sum. Both produce the
+# same `<hash>  <file>` format so callers can use them interchangeably.
+SHA1SUM := $(shell command -v sha1sum >/dev/null 2>&1 && echo sha1sum || echo "shasum -a 1")
 
 # Control the build verbosity
 ifeq ("$(VERBOSE)","1")

--- a/mk/external.mk
+++ b/mk/external.mk
@@ -7,6 +7,27 @@ TOP=$(shell pwd)
 CONF=$(TOP)/configs
 FILE=$(TOP)/target
 
+# ---------------------------------------------------------------------------
+# Prebuilt artifacts
+# ---------------------------------------------------------------------------
+# When KERNEL_DATA_SHA1 / INITRD_DATA_SHA1 are pinned (auto-populated by
+# .github/workflows/prebuilt.yml), the kernel image and rootfs.cpio targets
+# fetch precompressed binaries from the rolling `prebuilt` GitHub
+# prerelease instead of building Linux and BusyBox from source. Empty
+# values fall back to the source build.
+#
+# To pick up a freshly published release, paste the three values printed
+# in the workflow run notes into the assignments below and open a PR. The
+# CI drift check compares PREBUILT_INPUTS_SHA1 to a live hash of the
+# input files; if they disagree on a PR, the workflow rebuilds from
+# source on a Linux runner and hands the artifact to the test job.
+PREBUILT_REPO        = sysprog21/kvm-host
+PREBUILT_TAG         = prebuilt
+PREBUILT_BASE_URL    = https://github.com/$(PREBUILT_REPO)/releases/download/$(PREBUILT_TAG)
+KERNEL_DATA_SHA1     =
+INITRD_DATA_SHA1     =
+PREBUILT_INPUTS_SHA1 =
+
 # Linux kernel
 LINUX_VER = 7.0
 LINUX_SRC_URL = https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-${LINUX_VER}.tar.xz
@@ -23,8 +44,9 @@ define download-n-extract
 $(eval $(T)_SRC_ARCHIVE = $(OUT)/$(shell basename $($(T)_SRC_URL)))
 $($(T)_SRC_ARCHIVE):
 	$(VECHO) "  GET\t$$@\n"
+	$(Q)mkdir -p $$(@D)
 	$(Q)curl --progress-bar -o $$@ -L -C - "$(strip $($(T)_SRC_URL))"
-	$(Q)echo "$(strip $$($(T)_SRC_SHA1))  $$@" | shasum -c
+	$(Q)echo "$(strip $$($(T)_SRC_SHA1))  $$@" | $(SHA1SUM) -c
 $($(T)_SRC): $($(T)_SRC_ARCHIVE)
 	$(VECHO) "Unpacking $$@ ... "
 	$(Q)tar -xf $$< -C ${OUT} && $(call notice, [OK])
@@ -33,17 +55,36 @@ endef
 EXTERNAL_SRC = LINUX BUSYBOX
 $(foreach T,$(EXTERNAL_SRC),$(eval $(download-n-extract)))
 
-# Build Linux kernel image
-ifeq ($(ARCH), x86_64)
+# Architecture-specific kernel image name. Computed regardless of build
+# vs. download path so $(LINUX_IMG) is consistent for both. Prebuilt
+# artifacts are currently published only for the x86 guest image pair,
+# so arm64 always falls back to source builds.
+HOST_ARCH := $(ARCH)
+ifeq ($(HOST_ARCH), x86_64)
 LINUX_IMG_NAME = bzImage
 ARCH = x86
-else ifeq ($(ARCH), aarch64)
+PREBUILT_ARTIFACTS_SUPPORTED = 1
+else ifeq ($(HOST_ARCH), aarch64)
 LINUX_IMG_NAME = Image
 ARCH = arm64
 else
     $(error Unsupported architecture)
 endif
 LINUX_IMG := $(addprefix $(OUT)/,$(LINUX_IMG_NAME))
+ROOTFS_IMG = $(OUT)/rootfs.cpio
+PREBUILT_KERNEL_STAMP = $(OUT)/.prebuilt-kernel-$(KERNEL_DATA_SHA1).stamp
+PREBUILT_INITRD_STAMP = $(OUT)/.prebuilt-initrd-$(INITRD_DATA_SHA1).stamp
+
+# ---------------------------------------------------------------------------
+# Linux kernel image: source build OR prebuilt download
+# ---------------------------------------------------------------------------
+ifneq ($(PREBUILT_ARTIFACTS_SUPPORTED),1)
+USE_PREBUILT_KERNEL =
+else
+USE_PREBUILT_KERNEL = $(strip $(KERNEL_DATA_SHA1))
+endif
+
+ifeq ($(USE_PREBUILT_KERNEL),)
 
 $(LINUX_IMG): $(LINUX_SRC)
 	$(VECHO) "Configuring Linux kernel... "
@@ -63,6 +104,36 @@ $(LINUX_IMG): $(LINUX_SRC)
 	$(Q)(cd $< ; $(MAKE) ARCH=$(ARCH) $(LINUX_IMG_NAME) $(PARALLEL) $(REDIR))
 	$(Q)(cd $< ; cp -f arch/$(ARCH)/boot/$(LINUX_IMG_NAME) $(TOP)/$(OUT)) && $(call notice, [OK])
 
+else
+
+$(PREBUILT_KERNEL_STAMP):
+	$(Q)mkdir -p $(OUT)
+	$(Q)rm -f $(OUT)/.prebuilt-kernel-*.stamp
+	$(Q)touch $@
+
+$(LINUX_IMG): $(PREBUILT_KERNEL_STAMP)
+	$(VECHO) "  GET\t$@.bz2 (prebuilt)\n"
+	$(Q)mkdir -p $(OUT)
+	$(Q)rm -f $@ $@.bz2 $@.bz2.tmp
+	$(Q)curl --fail --progress-bar -L -o $@.bz2.tmp \
+	    "$(PREBUILT_BASE_URL)/$(LINUX_IMG_NAME).bz2"
+	$(Q)echo "$(KERNEL_DATA_SHA1)  $@.bz2.tmp" | $(SHA1SUM) -c
+	$(Q)mv -f $@.bz2.tmp $@.bz2
+	$(Q)bunzip2 -kf $@.bz2 && $(call notice, [OK])
+
+endif
+
+# ---------------------------------------------------------------------------
+# Rootfs: BusyBox source build OR prebuilt download
+# ---------------------------------------------------------------------------
+ifneq ($(PREBUILT_ARTIFACTS_SUPPORTED),1)
+USE_PREBUILT_INITRD =
+else
+USE_PREBUILT_INITRD = $(strip $(INITRD_DATA_SHA1))
+endif
+
+ifeq ($(USE_PREBUILT_INITRD),)
+
 # Build busybox single binary
 BUSYBOX_BIN = $(OUT)/rootfs/bin/busybox
 $(BUSYBOX_BIN): $(BUSYBOX_SRC)
@@ -75,7 +146,6 @@ $(BUSYBOX_BIN): $(BUSYBOX_SRC)
 	$(Q)(cd $< ; $(MAKE) CONFIG_PREFIX='../rootfs' install $(REDIR)) && $(call notice, [OK])
 
 # Generate root file system
-ROOTFS_IMG = $(OUT)/rootfs.cpio
 $(ROOTFS_IMG): $(BUSYBOX_BIN)
 	$(VECHO) "Generating root file system... "
 	$(Q)(cd $(OUT)/rootfs ; \
@@ -84,3 +154,22 @@ $(ROOTFS_IMG): $(BUSYBOX_BIN)
 	  cp -f $(FILE)/rc-startup etc/init.d/rcS ; \
 	  chmod 755 etc/init.d/rcS ; \
 	  find . | cpio -o --format=newc > $(abspath $@) 2>/dev/null) && $(call notice, [OK])
+
+else
+
+$(PREBUILT_INITRD_STAMP):
+	$(Q)mkdir -p $(OUT)
+	$(Q)rm -f $(OUT)/.prebuilt-initrd-*.stamp
+	$(Q)touch $@
+
+$(ROOTFS_IMG): $(PREBUILT_INITRD_STAMP)
+	$(VECHO) "  GET\t$@.bz2 (prebuilt)\n"
+	$(Q)mkdir -p $(OUT)
+	$(Q)rm -f $@ $@.bz2 $@.bz2.tmp
+	$(Q)curl --fail --progress-bar -L -o $@.bz2.tmp \
+	    "$(PREBUILT_BASE_URL)/rootfs.cpio.bz2"
+	$(Q)echo "$(INITRD_DATA_SHA1)  $@.bz2.tmp" | $(SHA1SUM) -c
+	$(Q)mv -f $@.bz2.tmp $@.bz2
+	$(Q)bunzip2 -kf $@.bz2 && $(call notice, [OK])
+
+endif

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Single entry point for building the prebuilt-publishable images. Wraps
+# the existing mk/external.mk targets so .github/workflows/prebuilt.yml
+# and the PR drift-rebuild path call the same code.
+
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+ARCH="${ARCH:-$(uname -m)}"
+case "$ARCH" in
+    x86_64)  IMG_NAME=bzImage ;;
+    aarch64) IMG_NAME=Image ;;
+    *) echo "Unsupported ARCH: $ARCH" >&2; exit 1 ;;
+esac
+
+show_help() {
+    cat <<EOF
+Usage: $0 [--linux] [--rootfs] [--all] [--clean]
+
+Options:
+  --linux    Build only the Linux kernel image (build/$IMG_NAME)
+  --rootfs   Build only the BusyBox initramfs (build/rootfs.cpio)
+  --all      Build both
+  --clean    Remove build/ before building
+  --help     Show this message
+EOF
+}
+
+build_linux=0
+build_rootfs=0
+clean=0
+
+[ $# -eq 0 ] && { show_help; exit 1; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --linux)  build_linux=1 ;;
+        --rootfs) build_rootfs=1 ;;
+        --all)    build_linux=1; build_rootfs=1 ;;
+        --clean)  clean=1 ;;
+        --help|-h) show_help; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; show_help; exit 1 ;;
+    esac
+    shift
+done
+
+[ $clean -eq 1 ] && rm -rf build
+
+# Force the source-build path even if mk/external.mk has SHA1 pins set --
+# this script's whole job is to (re)produce the prebuilt content.
+MAKE_ARGS=(KERNEL_DATA_SHA1= INITRD_DATA_SHA1=)
+PARALLEL=(-j "$(nproc 2>/dev/null || echo 4)")
+
+[ $build_linux  -eq 1 ] && make "${PARALLEL[@]}" "${MAKE_ARGS[@]}" "build/$IMG_NAME"
+[ $build_rootfs -eq 1 ] && make "${PARALLEL[@]}" "${MAKE_ARGS[@]}" build/rootfs.cpio
+
+ls -l "build/$IMG_NAME" build/rootfs.cpio 2>/dev/null || true


### PR DESCRIPTION
Build flow:
- mk/external.mk now fetches bzImage and rootfs.cpio from a fixed-tag GitHub prerelease when KERNEL_DATA_SHA1 / INITRD_DATA_SHA1 are pinned, falling back to source build otherwise. .github/workflows/prebuilt.yml republishes those assets on master pushes that touch image inputs and prints the three SHA1 lines to paste into mk/external.mk.
- For PRs that drift the inputs (configs, target/, mk/external.mk) from the pinned prebuilt, a new pr-prebuilt-build job rebuilds the images from source on a Linux runner and hands them to the test job via workflow artifact (with stamp files staged so make does not redownload the OLD prerelease over the freshly-built artifact). .ci/inputs-hash.sh is the canonical hash so the publish step and the drift check always agree.

Test flow:
- Replace the build-only host-x64 job with an end-to-end boot test: .ci/autorun.sh drives \`make check\` under expect, asserts the guest reaches a busybox shell, runs uname, and exits via the Ctrl-A x escape recognized by src/serial.c.
- Preflight /dev/kvm and install expect + e2fsprogs alongside the existing build deps.