### PR TITLE
Preserve full BAR layout across guest sizing

### DIFF
--- a/src/pci.c
+++ b/src/pci.c
@@ -145,14 +145,13 @@ static void pci_mmio_io(void *owner,
 void pci_set_bar(struct pci_dev *dev,
                  uint8_t bar,
                  uint32_t bar_size,
-                 bool is_io_space,
+                 uint32_t layout,
                  dev_io_fn do_io)
 {
-    /* TODO: mem type, prefetch */
     /* FIXME: bar_size must be power of 2 */
-    PCI_HDR_WRITE(dev->hdr, PCI_BAR_OFFSET(bar), is_io_space, 32);
+    PCI_HDR_WRITE(dev->hdr, PCI_BAR_OFFSET(bar), layout, 32);
     dev->bar_size[bar] = bar_size;
-    dev->bar_is_io_space[bar] = is_io_space;
+    dev->bar_is_io_space[bar] = layout & 0x1U;  // Get the bit[0] of layout
     dev_init(&dev->space_dev[bar], 0, bar_size, dev, do_io);
 }
 

--- a/src/pci.c
+++ b/src/pci.c
@@ -52,8 +52,9 @@ static void pci_command_bar(struct pci_dev *dev)
     bool enable_mem =
         PCI_HDR_READ(dev->hdr, PCI_COMMAND, 16) & PCI_COMMAND_MEMORY;
     for (int i = 0; i < PCI_STD_NUM_BARS; i++) {
-        struct bus *bus = dev->bar_is_io_space[i] ? dev->io_bus : dev->mmio_bus;
-        bool enable = dev->bar_is_io_space[i] ? enable_io : enable_mem;
+        bool is_io = dev->bar_layout[i] & PCI_BASE_ADDRESS_SPACE_IO;
+        struct bus *bus = is_io ? dev->io_bus : dev->mmio_bus;
+        bool enable = is_io ? enable_io : enable_mem;
 
         if (enable)
             pci_activate_bar(dev, i, bus);
@@ -71,9 +72,9 @@ static void pci_config_bar(struct pci_dev *dev, uint8_t bar)
 {
     uint32_t mask = ~(dev->bar_size[bar] - 1);
     uint32_t old_bar = PCI_HDR_READ(dev->hdr, PCI_BAR_OFFSET(bar), 32);
-    uint32_t new_bar = (old_bar & mask) | dev->bar_is_io_space[bar];
+    uint32_t new_bar = (old_bar & mask) | (dev->bar_layout[bar] & ~mask);
     PCI_HDR_WRITE(dev->hdr, PCI_BAR_OFFSET(bar), new_bar, 32);
-    dev->space_dev[bar].base = new_bar;
+    dev->space_dev[bar].base = new_bar & mask;
 }
 
 static void pci_config_write(struct pci_dev *dev,
@@ -148,10 +149,14 @@ void pci_set_bar(struct pci_dev *dev,
                  uint32_t layout,
                  dev_io_fn do_io)
 {
-    /* FIXME: bar_size must be power of 2 */
+    /*
+     * FIXME: bar_size must be a power of two.
+     * TODO: 64-bit BARs need a second adjacent slot for the upper dword;
+     * only 32-bit memory and I/O BARs are wired up here.
+     */
     PCI_HDR_WRITE(dev->hdr, PCI_BAR_OFFSET(bar), layout, 32);
     dev->bar_size[bar] = bar_size;
-    dev->bar_is_io_space[bar] = layout & 0x1U;  // Get the bit[0] of layout
+    dev->bar_layout[bar] = layout;
     dev_init(&dev->space_dev[bar], 0, bar_size, dev, do_io);
 }
 

--- a/src/pci.h
+++ b/src/pci.h
@@ -46,10 +46,39 @@ struct pci {
     struct dev pci_mmio_dev;
 };
 
+/**
+ * @brief Configure and initialize a PCI Base Address Register (BAR).
+ *
+ * This writes the caller-provided layout bitmask into the BAR register
+ * in the PCI configuration header, records the region size and I/O type,
+ * and sets up the address space (MMIO or port I/O) with the specified
+ * callback.
+ *
+ * @param dev         Pointer to the pci_dev representing the device.
+ * @param bar         BAR index to program (0–5 in a standard PCI header).
+ * @param bar_size    Size of the BAR region in bytes (must be a power of two).
+ * @param layout      Bitmask of PCI_BASE_ADDRESS_* flags defined in
+ *                    `/usr/include/linux/pci_regs.h`:
+ *                    - Bit 0: I/O space (1) vs. memory space (0)
+ *                      (`PCI_BASE_ADDRESS_SPACE_IO` or
+ *                       `PCI_BASE_ADDRESS_SPACE_MEMORY`)
+ *                    - Bits [2:1]: Memory decoding type
+ *                      (`PCI_BASE_ADDRESS_MEM_TYPE_32` or
+ *                       `PCI_BASE_ADDRESS_MEM_TYPE_64`)
+ *                    - Bit 3: Prefetchable flag for memory
+ *                      (`PCI_BASE_ADDRESS_MEM_PREFETCH`)
+ * @param do_io       Callback (dev_io_fn) invoked on accesses within
+ *                    the BAR region.
+ *
+ * @note bar_size must be a power of two for correct decoding by the
+ *       PCI framework.
+ * @note For 64-bit memory BARs, callers must reserve the next BAR index
+ *       (n+1) for the high 32 bits if required by the platform.
+ */
 void pci_set_bar(struct pci_dev *dev,
                  uint8_t bar,
                  uint32_t bar_size,
-                 bool is_io_space,
+                 uint32_t is_io_space,
                  dev_io_fn do_io);
 void pci_set_status(struct pci_dev *dev, uint16_t status);
 void pci_dev_register(struct pci_dev *dev);

--- a/src/pci.h
+++ b/src/pci.h
@@ -30,7 +30,7 @@ struct pci_dev {
     void *hdr;
     uint32_t bar_size[6];
     bool bar_active[6];
-    bool bar_is_io_space[6];
+    uint32_t bar_layout[6];
     struct dev space_dev[6];
     struct dev config_dev;
     struct bus *io_bus;
@@ -46,39 +46,15 @@ struct pci {
     struct dev pci_mmio_dev;
 };
 
-/**
- * @brief Configure and initialize a PCI Base Address Register (BAR).
- *
- * This writes the caller-provided layout bitmask into the BAR register
- * in the PCI configuration header, records the region size and I/O type,
- * and sets up the address space (MMIO or port I/O) with the specified
- * callback.
- *
- * @param dev         Pointer to the pci_dev representing the device.
- * @param bar         BAR index to program (0–5 in a standard PCI header).
- * @param bar_size    Size of the BAR region in bytes (must be a power of two).
- * @param layout      Bitmask of PCI_BASE_ADDRESS_* flags defined in
- *                    `/usr/include/linux/pci_regs.h`:
- *                    - Bit 0: I/O space (1) vs. memory space (0)
- *                      (`PCI_BASE_ADDRESS_SPACE_IO` or
- *                       `PCI_BASE_ADDRESS_SPACE_MEMORY`)
- *                    - Bits [2:1]: Memory decoding type
- *                      (`PCI_BASE_ADDRESS_MEM_TYPE_32` or
- *                       `PCI_BASE_ADDRESS_MEM_TYPE_64`)
- *                    - Bit 3: Prefetchable flag for memory
- *                      (`PCI_BASE_ADDRESS_MEM_PREFETCH`)
- * @param do_io       Callback (dev_io_fn) invoked on accesses within
- *                    the BAR region.
- *
- * @note bar_size must be a power of two for correct decoding by the
- *       PCI framework.
- * @note For 64-bit memory BARs, callers must reserve the next BAR index
- *       (n+1) for the high 32 bits if required by the platform.
+/*
+ * Configure a PCI BAR. @layout is a bitmask of PCI_BASE_ADDRESS_* flags
+ * from <linux/pci_regs.h> (space, mem type, prefetch). The non-address
+ * bits are preserved across guest BAR sizing probes.
  */
 void pci_set_bar(struct pci_dev *dev,
                  uint8_t bar,
                  uint32_t bar_size,
-                 uint32_t is_io_space,
+                 uint32_t layout,
                  dev_io_fn do_io);
 void pci_set_status(struct pci_dev *dev, uint16_t status);
 void pci_dev_register(struct pci_dev *dev);

--- a/src/virtio-pci.c
+++ b/src/virtio-pci.c
@@ -268,7 +268,9 @@ void virtio_pci_init(struct virtio_pci_dev *dev,
     PCI_HDR_WRITE(dev->pci_dev.hdr, PCI_HEADER_TYPE, PCI_HEADER_TYPE_NORMAL, 8);
     PCI_HDR_WRITE(dev->pci_dev.hdr, PCI_INTERRUPT_PIN, 1, 8);
     pci_set_status(&dev->pci_dev, PCI_STATUS_CAP_LIST | PCI_STATUS_INTERRUPT);
-    pci_set_bar(&dev->pci_dev, 0, 0x100, PCI_BASE_ADDRESS_SPACE_MEMORY,
+    pci_set_bar(&dev->pci_dev, 0, 0x100,
+                PCI_BASE_ADDRESS_SPACE_MEMORY | PCI_BASE_ADDRESS_MEM_TYPE_32
+                /* | PCI_BASE_ADDRESS_MEM_PREFETCH */,
                 virtio_pci_space_io);
     virtio_pci_set_cap(dev, cap_list);
     dev->device_feature |=

--- a/src/virtio-pci.c
+++ b/src/virtio-pci.c
@@ -269,8 +269,7 @@ void virtio_pci_init(struct virtio_pci_dev *dev,
     PCI_HDR_WRITE(dev->pci_dev.hdr, PCI_INTERRUPT_PIN, 1, 8);
     pci_set_status(&dev->pci_dev, PCI_STATUS_CAP_LIST | PCI_STATUS_INTERRUPT);
     pci_set_bar(&dev->pci_dev, 0, 0x100,
-                PCI_BASE_ADDRESS_SPACE_MEMORY | PCI_BASE_ADDRESS_MEM_TYPE_32
-                /* | PCI_BASE_ADDRESS_MEM_PREFETCH */,
+                PCI_BASE_ADDRESS_SPACE_MEMORY | PCI_BASE_ADDRESS_MEM_TYPE_32,
                 virtio_pci_space_io);
     virtio_pci_set_cap(dev, cap_list);
     dev->device_feature |=


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keep the full PCI BAR layout (space, mem type, prefetch) intact across guest sizing and fix I/O BAR routing. Also switch pci_set_bar to a single layout bitmask for simpler, accurate BAR setup.

- **Bug Fixes**
  - Preserve all non-address BAR flags on guest config writes to avoid dropping MEM_TYPE/PREFETCH.
  - Mask the address into space_dev[bar].base, preventing the SPACE_IO bit from corrupting the base and breaking first-port lookup.

- **Migration**
  - Update calls to pci_set_bar(dev, bar, size, layout, io_fn); pass PCI_BASE_ADDRESS_* flags (e.g., MEMORY | MEM_TYPE_32).
  - Replace any internal use of bar_is_io_space[] with bar_layout[].
  - 64-bit BARs still require a paired adjacent slot; only 32-bit memory and I/O BARs are wired here.

<sup>Written for commit 833b3d0321b07cebfb5cef19c240115b278d872c. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/kvm-host/pull/48?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

