### PR TITLE
Harden guest exit, reset, and disk I/O paths

### DIFF
--- a/src/arch/arm64/desc.h
+++ b/src/arch/arm64/desc.h
@@ -1,7 +1,17 @@
 #pragma once
 
 #define RAM_BASE (1UL << 31)
+
+/* GIC SPIs (offset by ARM_GIC_SPI_BASE inside vm_irq_line). Distinct lines per
+ * device so a level-triggered ARM GIC can de-assert per source rather than
+ * sharing a vector across virtio paths.
+ */
 #define SERIAL_IRQ 0
 #define VIRTIO_BLK_IRQ 1
 #define VIRTIO_NET_IRQ 2
-#define KERNEL_OPTS "console=ttyS0"
+
+/* panic=-1 reboots immediately on guest panic. arm64 has no keyboard reset
+ * path; the kernel issues a PSCI SYSTEM_RESET / SYSTEM_OFF, which KVM
+ * surfaces as KVM_EXIT_SYSTEM_EVENT and vm_run() handles as a clean exit.
+ */
+#define KERNEL_OPTS "console=ttyS0 panic=-1"

--- a/src/arch/arm64/vm.c
+++ b/src/arch/arm64/vm.c
@@ -92,6 +92,13 @@ int vm_arch_cpu_init(vm_t *v)
     if (ioctl(v->vm_fd, KVM_ARM_PREFERRED_TARGET, &vcpu_init) < 0)
         return throw_err("Failed to find perferred CPU type\n");
 
+    /* Enable in-kernel PSCI 0.2 emulation. Without this, a guest panic with
+     * panic=-1 issues SYSTEM_OFF and KVM either ignores the SMC/HVC (so the
+     * guest spins) or signals an undefined-instruction trap. With PSCI on,
+     * the call surfaces as KVM_EXIT_SYSTEM_EVENT to the host loop.
+     */
+    vcpu_init.features[0] |= 1 << KVM_ARM_VCPU_PSCI_0_2;
+
     if (ioctl(v->vcpu_fd, KVM_ARM_VCPU_INIT, &vcpu_init))
         return throw_err("Failed to initialize vCPU\n");
 
@@ -142,9 +149,9 @@ int vm_arch_init_platform_device(vm_t *v)
     if (serial_init(&v->serial, &v->io_bus))
         return throw_err("Failed to init UART device");
 
-    /* Zero virtio_blk_dev so pci_dev_is_registered() observes a clean
-     * state when the user boots without -d. virtio_net_init memsets
-     * inside vm_enable_net, so virtio_net_dev is covered by that path.
+    /* Zero virtio_blk_dev so pci_dev_is_registered() observes a clean state
+     * when the user boots without -d. virtio_net_init memsets inside
+     * vm_enable_net, so virtio_net_dev is covered by that path.
      * x86 already does the same call in its vm_arch_init_platform_device.
      */
     virtio_blk_init(&v->virtio_blk_dev);
@@ -345,6 +352,17 @@ static int generate_fdt(vm_t *v)
     __FDT(property, "interrupt-controller", NULL, 0);
     __FDT(property, "reg", &gic_reg, sizeof(gic_reg));
     __FDT(property_cell, "phandle", FDT_PHANDLE_GIC);
+    __FDT(end_node);
+
+    /* /psci node: lets the guest discover the in-kernel PSCI 0.2 emulator
+     * we requested in vm_arch_cpu_init via KVM_ARM_VCPU_PSCI_0_2. KVM uses
+     * HVC as the conduit on the virtual CPU. Without this node the kernel
+     * doesn't know the firmware interface exists and falls back to a
+     * spinloop on panic.
+     */
+    __FDT(begin_node, "psci");
+    __FDT(property_string, "compatible", "arm,psci-0.2");
+    __FDT(property_string, "method", "hvc");
     __FDT(end_node);
 
     /* /uart node: serial device */

--- a/src/arch/x86/desc.h
+++ b/src/arch/x86/desc.h
@@ -1,7 +1,17 @@
 #pragma once
 
 #define RAM_BASE 0
+
+/* IO-APIC GSIs. Each device gets its own line so we never share a vector
+ * between virtio devices, which keeps level-triggered ISA legacy IRQs (the
+ * 16550 on IRQ4) out of the way of edge-triggered virtio MSI-less paths.
+ */
 #define SERIAL_IRQ 4
 #define VIRTIO_NET_IRQ 14
 #define VIRTIO_BLK_IRQ 15
-#define KERNEL_OPTS "console=ttyS0 pci=conf1"
+
+/* panic=-1 reboots immediately on guest panic; reboot=k uses the keyboard
+ * controller path which on KVM ends in a triple-fault, surfacing cleanly as
+ * KVM_EXIT_SHUTDOWN to the host loop in vm_run().
+ */
+#define KERNEL_OPTS "console=ttyS0 pci=conf1 panic=-1 reboot=k"

--- a/src/diskimg.c
+++ b/src/diskimg.c
@@ -9,8 +9,10 @@ ssize_t diskimg_read(struct diskimg *diskimg,
                      off_t offset,
                      size_t size)
 {
-    lseek(diskimg->fd, offset, SEEK_SET);
-    return read(diskimg->fd, data, size);
+    /* pread/pwrite carry the offset in the syscall, so concurrent virtq
+     * workers cannot race on a shared file pointer the way lseek+read does.
+     */
+    return pread(diskimg->fd, data, size, offset);
 }
 
 ssize_t diskimg_write(struct diskimg *diskimg,
@@ -18,8 +20,7 @@ ssize_t diskimg_write(struct diskimg *diskimg,
                       off_t offset,
                       size_t size)
 {
-    lseek(diskimg->fd, offset, SEEK_SET);
-    return write(diskimg->fd, data, size);
+    return pwrite(diskimg->fd, data, size, offset);
 }
 
 int diskimg_flush(struct diskimg *diskimg)
@@ -33,7 +34,11 @@ int diskimg_init(struct diskimg *diskimg, const char *file_path)
     if (diskimg->fd < 0)
         return -1;
     struct stat st;
-    fstat(diskimg->fd, &st);
+    if (fstat(diskimg->fd, &st) < 0) {
+        close(diskimg->fd);
+        diskimg->fd = -1;
+        return -1;
+    }
     diskimg->size = st.st_size;
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -77,8 +77,6 @@ int main(int argc, char *argv[])
         }
     }
 
-    set_input_mode();
-
     vm_t vm;
     if (vm_init(&vm) < 0)
         return throw_err("Failed to initialize guest vm");
@@ -98,6 +96,11 @@ int main(int argc, char *argv[])
 
     if (vm_late_init(&vm) < 0)
         return -1;
+
+    /* Switch the terminal to raw mode only once setup has succeeded so that
+     * any error from the load/init paths above is rendered on a normal tty.
+     */
+    set_input_mode();
 
     vm_run(&vm);
     vm_exit(&vm);

--- a/src/virtio-blk.c
+++ b/src/virtio-blk.c
@@ -275,7 +275,6 @@ static int virtio_blk_setup(struct virtio_blk_dev *dev, struct diskimg *diskimg)
     }
 
     dev->enable = true;
-    /* FIXME: irq_num should be different to other devs */
     dev->irq_num = VIRTIO_BLK_IRQ;
     dev->diskimg = diskimg;
     dev->config.capacity = diskimg->size >> 9;

--- a/src/virtio-pci.c
+++ b/src/virtio-pci.c
@@ -46,7 +46,39 @@ static void virtio_pci_write_guest_feature(struct virtio_pci_dev *dev)
 
 static void virtio_pci_reset(struct virtio_pci_dev *dev)
 {
-    /* TODO: virtio pci reset */
+    /* Virtio 1.x §2.4: writing 0 to device_status resets the device to its
+     * initial post-power-on state. We clear the negotiated bits the guest
+     * is about to re-write: acked features, ISR, the per-virtq packed-ring
+     * indices, and the common-cfg selector bytes. This is sufficient for a
+     * driver re-probe (reload, kexec) where the guest hasn't yet enabled
+     * any virtqueue.
+     *
+     * We deliberately leave info.enable, desc_ring, and the device/driver
+     * event pointers alone, because the device-emulator workers in
+     * virtio-blk / virtio-net poll those without locking. A full reset that
+     * tears down enabled queues would have to write the per-device stopfd
+     * and pthread_join the workers, which the generic virtio-pci layer has
+     * no handle on — leaving that for a follow-up that adds a
+     * virtio_pci_ops::reset hook.
+     */
+    dev->guest_feature = 0;
+    dev->config.common_cfg.device_feature_select = 0;
+    dev->config.common_cfg.guest_feature_select = 0;
+    dev->config.common_cfg.guest_feature = 0;
+    dev->config.common_cfg.queue_select = 0;
+    __atomic_store_n(&dev->config.isr_cap.isr_status, 0, __ATOMIC_RELEASE);
+
+    for (uint16_t i = 0; i < dev->num_queues; i++) {
+        struct virtq *vq = &dev->vq[i];
+        if (vq->info.enable)
+            continue;
+        vq->info.size = VIRTQ_SIZE;
+        vq->info.desc_addr = 0;
+        vq->info.device_addr = 0;
+        vq->info.driver_addr = 0;
+        vq->next_avail_idx = 0;
+        vq->used_wrap_count = 1;
+    }
 }
 
 static void virtio_pci_write_status(struct virtio_pci_dev *dev)
@@ -62,7 +94,7 @@ static void virtio_pci_select_virtq(struct virtio_pci_dev *dev)
     uint16_t select = dev->config.common_cfg.queue_select;
     struct virtio_pci_common_cfg *config = &dev->config.common_cfg;
 
-    if (select < config->num_queues) {
+    if (select < dev->num_queues) {
         uint64_t offset = offsetof(struct virtio_pci_common_cfg, queue_size);
         memcpy((void *) ((uintptr_t) config + offset), &dev->vq[select].info,
                sizeof(struct virtq_info));
@@ -114,7 +146,7 @@ static void virtio_pci_space_write(struct virtio_pci_dev *dev,
                 offset <= VIRTIO_PCI_COMMON_Q_USEDHI) {
                 uint16_t select = dev->config.common_cfg.queue_select;
                 uint64_t info_offset = offset - VIRTIO_PCI_COMMON_Q_SIZE;
-                if (select < dev->config.common_cfg.num_queues) {
+                if (select < dev->num_queues) {
                     memcpy((void *) ((uintptr_t) &dev->vq[select].info +
                                      info_offset),
                            data, size);
@@ -251,6 +283,7 @@ void virtio_pci_set_virtq(struct virtio_pci_dev *dev,
                           struct virtq *vq,
                           uint16_t num_queues)
 {
+    dev->num_queues = num_queues;
     dev->config.common_cfg.num_queues = num_queues;
     dev->vq = vq;
 }

--- a/src/virtio-pci.h
+++ b/src/virtio-pci.h
@@ -35,6 +35,13 @@ struct virtio_pci_dev {
     struct virtio_pci_notify_cap *notify_cap;
     struct virtio_pci_cap *dev_cfg_cap;
     struct virtq *vq;
+    /* Host-side mirror of the queue count. config.common_cfg.num_queues
+     * lives in guest-writable BAR memory (the unconditional memcpy in
+     * virtio_pci_space_write lets a guest overwrite it), so trusting it
+     * to bound vq[] indexing is an OOB-write primitive. Bounds checks
+     * use this field instead.
+     */
+    uint16_t num_queues;
 };
 
 uint64_t virtio_pci_get_notify_addr(struct virtio_pci_dev *dev,

--- a/src/vm.c
+++ b/src/vm.c
@@ -161,6 +161,20 @@ int vm_run(vm_t *v)
             printf("shutdown\n");
             munmap(run, run_size);
             return 0;
+        case KVM_EXIT_SYSTEM_EVENT: {
+            /* arm64 PSCI SYSTEM_OFF / SYSTEM_RESET land here. SHUTDOWN and
+             * RESET are clean exits from our POV — kvm-host has no reboot
+             * loop, and a guest panic with panic=-1 reaches us as RESET
+             * (indistinguishable from a userspace `reboot`), matching the
+             * x86 reboot=k path that comes back as KVM_EXIT_SHUTDOWN.
+             * CRASH is the one type that signals host-relevant failure
+             * (NMI watchdog, kdump trigger), so propagate it as -1.
+             */
+            uint32_t type = run->system_event.type;
+            printf("system event %u\n", type);
+            munmap(run, run_size);
+            return type == KVM_SYSTEM_EVENT_CRASH ? -1 : 0;
+        }
         default:
             printf("reason: %d\n", run->exit_reason);
             munmap(run, run_size);


### PR DESCRIPTION
- Switch the disk-image backend to pread/pwrite so a future second virtio-blk virtqueue cannot race on the shared file pointer, and check the fstat return on open so initialization fails loudly on a kernel error instead of silently reading st.st_size from uninitialized stack.

- Defer the terminal raw-mode switch until guest setup succeeds, so any error during image load or device init renders on a normal tty instead of a half-cooked terminal.

- Implement virtio-pci device reset. The previous no-op left acked features and the ISR live across re-probe, so a guest reload would observe stale negotiation state. The new reset clears acked features, the ISR, the common-cfg selectors, and the per-virtq indices for any queue that was never enabled. Enabled queues are deliberately left alone because the per-device worker threads poll the descriptor ring without a lock; a full tear-down needs a per-device reset hook that does not exist yet, and clearing state underneath a running worker is worse than leaving it stale.

- Handle KVM_EXIT_SYSTEM_EVENT in the run loop. SHUTDOWN and RESET are clean exits — a guest panic with panic=-1 reaches us as RESET, which is indistinguishable from a userspace reboot and matches the x86 reboot=k path that comes back as KVM_EXIT_SHUTDOWN. CRASH propagates as -1 so kdump and NMI watchdog signals reach the host exit code.

- Append panic=-1 (plus reboot=k on x86) to the guest kernel cmdline so a guest panic terminates the VM instead of hanging in panic() until Ctrl-A x. Also document the IRQ map: serial, blk, and net have always been distinct lines, but a stale FIXME suggested otherwise.

- On arm64, enable in-kernel PSCI 0.2 emulation (KVM_ARM_VCPU_PSCI_0_2 in vcpu features) and advertise it via a device-tree node with method set to hvc. Without this, SYSTEM_RESET issued by panic=-1 is either ignored — leaving the guest spinning — or trapped as undef instead of surfacing to the host loop.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened VM shutdown/reset, virtio queue bounds, and disk I/O. Adds proper `virtio-pci` reset, host-side queue count validation, clean KVM system-event exits, and panic-to-exit by default; disk I/O now uses `pread`/`pwrite` and setup errors render on a normal TTY.

- **New Features**
  - `virtio-pci` reset + queue bounds hardening: clears acked features, ISR, selectors, and non-enabled virtq indices; preserves enabled queues; bounds checks use a host `num_queues` cache to block guest OOB writes.
  - Handle KVM system events: SHUTDOWN/RESET exit 0; CRASH exits -1.
  - Panic-to-exit by default: add "panic=-1" (and "reboot=k" on x86); arm64 enables in-kernel PSCI 0.2 and exposes a `/psci` FDT node (method "hvc").

- **Bug Fixes**
  - Disk I/O uses `pread`/`pwrite` to avoid shared file-pointer races; `fstat` is checked and open fails cleanly on error.
  - Defer switching the terminal to raw mode until after guest setup to keep error output readable.

<sup>Written for commit 59530e73d527b9d1222982dbe61bfa9331598710. Summary will update on new commits. <a href="https://cubic.dev/pr/sysprog21/kvm-host/pull/52?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

